### PR TITLE
Fix aes-128-ctr cipher name

### DIFF
--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	version3        = 3
-	cipherAES128ctr = "es-128-ctr"
+	cipherAES128ctr = "aes-128-ctr"
 	kdfTypeScrypt   = "scrypt"
 	kdfTypePbkdf2   = "pbkdf2"
 )


### PR DESCRIPTION
The commit message was bigger than the diff. But an important fix, nonetheless. 