### PR TITLE
Expose ABI Parameter on TypeComponent

### DIFF
--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -48,12 +48,12 @@ type TypeComponent interface {
 	ElementaryType() ElementaryTypeInfo // only non-nil for elementary components
 	ArrayChild() TypeComponent          // only non-nil for array components
 	TupleChildren() []TypeComponent     // only non-nil for tuple components
-	KeyName() string                    // the name of the ABI property/component
+	KeyName() string                    // the name of the ABI property/component, only set for top-level parameters and tuple entries
+	Parameter() *Parameter              // the ABI property/component, only set for top-level parameters and tuple entries
 	ParseExternal(v interface{}) (*ComponentValue, error)
 	ParseExternalCtx(ctx context.Context, v interface{}) (*ComponentValue, error)
 	DecodeABIData(d []byte, offset int) (*ComponentValue, error)
 	DecodeABIDataCtx(ctx context.Context, d []byte, offest int) (*ComponentValue, error)
-	Parameter() *Parameter
 }
 
 type typeComponent struct {

--- a/pkg/abi/typecomponents_test.go
+++ b/pkg/abi/typecomponents_test.go
@@ -679,3 +679,34 @@ func TestTypeComponentParseExternalOk(t *testing.T) {
 	assert.Equal(t, "test", cv.Value)
 
 }
+
+func TestTypeInternalTypeIndexed(t *testing.T) {
+
+	abiString := `[
+		{
+		  "name": "f",
+		  "type": "function",
+		  "inputs": [
+			{
+				"name": "a",
+				"type": "uint256[]",
+				"internalType": "uint256[]",
+				"indexed": true
+
+			}
+		  ],
+		  "outputs": []
+		}
+	  ]`
+	var abi ABI
+	err := json.Unmarshal([]byte(abiString), &abi)
+	assert.NoError(t, err)
+	err = abi.Validate()
+	assert.NoError(t, err)
+
+	tc, err := abi.Functions()["f"].Inputs[0].TypeComponentTree()
+	assert.NoError(t, err)
+	assert.Equal(t, "uint256[]", tc.Parameter().Type)
+	assert.Equal(t, "uint256[]", tc.Parameter().InternalType)
+	assert.Equal(t, true, tc.Parameter().Indexed)
+}


### PR DESCRIPTION
While writing the code in FireFly core to traverse the component tree, these three fields present on the `abi` are needed as well. I solved this by attaching the original `Parameter` to the `TypeComponent` struct/interface.