### PR TITLE
Proposal to standardize elementary type info in the abi package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.txt
 **/debug.test
 .DS_Store
 __debug*
+.vscode/*.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "ethsigner",
     "ethsignermocks",
     "ethtypes",
+    "ffiinputtype",
     "ffresty",
     "ffsigner",
     "fftypes",

--- a/internal/signermsgs/en_api_translations.go
+++ b/internal/signermsgs/en_api_translations.go
@@ -28,4 +28,7 @@ var ffm = func(key, translation string) i18n.MessageKey {
 //revive:disable
 var (
 	APIIntegerDescription = ffm("api.integer", "An integer. You are recommended to use a JSON string. A JSON number can be used for values up to the safe maximum.")
+	APIBoolDescription    = ffm("api.bool", "A boolean. You can use a boolean or a string true/false as input")
+	APIFloatDescription   = ffm("api.float", "A floating point number, which will be converted to a fixed point number. You are recommended to use a JSON string. A JSON number can be used for values up to the safe maximum.")
+	APIHexDescription     = ffm("api.hex", "A hex encoded set of bytes, with an optional '0x' prefix")
 )

--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -64,7 +64,7 @@ var (
 	MsgNumberTooLargeABIEncode      = ffe("FF22044", "Numeric value does not fit in bit length %d for ABI encoding of component %s")
 	MsgNotEnoughtBytesABIArrayCount = ffe("FF22045", "Insufficient bytes to read array index for component %s")
 	MsgABIArrayCountTooLarge        = ffe("FF22046", "Array index %s too large for component %s")
-	MsgNotEnoughtBytesABIValue      = ffe("FF22047", "Insufficient bytes to read %s value %s")
+	MsgNotEnoughBytesABIValue       = ffe("FF22047", "Insufficient bytes to read %s value %s")
 	MsgNotEnoughtBytesABISignature  = ffe("FF22048", "Insufficient bytes to read signature")
 	MsgIncorrectABISignatureID      = ffe("FF22049", "Incorrect ID for signature %s expected=%s found=%s")
 	MsgUnknownABIElementaryType     = ffe("FF22050", "Unknown elementary type %s for component %s")

--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -68,7 +68,7 @@ func decodeABIElement(ctx context.Context, breadcrumbs string, block []byte, hea
 func decodeABISignedInt(ctx context.Context, desc string, block []byte, headStart, headPosition int, component *typeComponent) (cv *ComponentValue, err error) {
 	cv = &ComponentValue{Component: component}
 	if headPosition+32 > len(block) {
-		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughtBytesABIValue, component, desc)
+		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
 	}
 	cv.Value = ParseInt256TwosComplementBytes(block[headPosition : headPosition+32])
 	return cv, err
@@ -77,7 +77,7 @@ func decodeABISignedInt(ctx context.Context, desc string, block []byte, headStar
 func decodeABIUnsignedInt(ctx context.Context, desc string, block []byte, headStart, headPosition int, component *typeComponent) (cv *ComponentValue, err error) {
 	cv = &ComponentValue{Component: component}
 	if headPosition+32 > len(block) {
-		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughtBytesABIValue, component, desc)
+		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
 	}
 	cv.Value = new(big.Int).SetBytes(block[headPosition : headPosition+32])
 	return cv, err
@@ -141,7 +141,7 @@ func decodeABIBytes(ctx context.Context, desc string, block []byte, headStart, h
 	}
 	cv = &ComponentValue{Component: component}
 	if dataOffset+byteLength > len(block) {
-		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughtBytesABIValue, component, desc)
+		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
 	}
 	b := make([]byte, byteLength)
 	copy(b, block[dataOffset:])

--- a/pkg/abi/typecomponents_test.go
+++ b/pkg/abi/typecomponents_test.go
@@ -34,6 +34,7 @@ func TestElementalTypeInfoRules(t *testing.T) {
 	assert.Equal(t, "bytes / bytes<M> (1 <= M <= 32)", ElementaryTypeBytes.String())
 	assert.Equal(t, "function", ElementaryTypeFunction.String())
 	assert.Equal(t, "string", ElementaryTypeString.String())
+	assert.Equal(t, JSONEncodingTypeString, ElementaryTypeString.JSONEncodingType())
 
 }
 


### PR DESCRIPTION
Here's my proposal for how to address my suggestion in https://github.com/hyperledger/firefly-signer/pull/9#discussion_r905462373

Note I filled in the gap on the floating point input, with a `oneOf` there, and this means the test fails due to `number` being missing from: https://github.com/hyperledger/firefly-common/blob/7f6b2eaf8066c146f377864981e92ea9e1f43903/pkg/fftypes/ffi_param_validator.go#L54-L58

> PR submitted here for common: https://github.com/hyperledger/firefly-common/pull/21