### PR TITLE
Fix oneOf FFI param schema

### DIFF
--- a/pkg/ffi2abi/ffi_test.go
+++ b/pkg/ffi2abi/ffi_test.go
@@ -888,11 +888,11 @@ func TestConvertFFIEventDefinitionToABIInvalidSchema(t *testing.T) {
 
 func TestProcessFieldInvalidSchema(t *testing.T) {
 	s := &Schema{
-		Type:    fftypes.JSONAnyPtr(`"object"`),
+		Type:    "object",
 		Details: &paramDetails{},
 		Properties: map[string]*Schema{
 			"badProperty": {
-				Type: fftypes.JSONAnyPtr("foo"),
+				Type: "foo",
 			},
 		},
 	}
@@ -978,37 +978,41 @@ func TestConvertFFIParamsToABIParametersTypeMismatch(t *testing.T) {
 }
 
 func TestInputTypeValidForTypeComponent(t *testing.T) {
-	inputType := fftypes.JSONAnyPtr(`"boolean"`)
+	inputSchema := &Schema{
+		Type: "boolean",
+	}
 	param := abi.Parameter{
 		Type: "bool",
 	}
 	tc, _ := param.TypeComponentTree()
-	assert.True(t, inputTypeValidForTypeComponent(context.Background(), inputType, tc))
+	assert.True(t, inputTypeValidForTypeComponent(inputSchema, tc))
 }
 
 func TestInputTypeValidForTypeComponentOneOf(t *testing.T) {
-	inputType := fftypes.JSONAnyPtr(`{
-		"oneOf": [
+	inputSchema := &Schema{
+		OneOf: []SchemaType{
 			{
-				"type": "integer"
+				Type: "integer",
 			},
 			{
-				"type": "string"
-			}
-		]
-	}`)
+				Type: "string",
+			},
+		},
+	}
 	param := abi.Parameter{
 		Type: "uint256",
 	}
 	tc, _ := param.TypeComponentTree()
-	assert.True(t, inputTypeValidForTypeComponent(context.Background(), inputType, tc))
+	assert.True(t, inputTypeValidForTypeComponent(inputSchema, tc))
 }
 
 func TestInputTypeValidForTypeComponentInvalid(t *testing.T) {
-	inputType := fftypes.JSONAnyPtr(`"foobar"`)
+	inputSchema := &Schema{
+		Type: "foobar",
+	}
 	param := abi.Parameter{
 		Type: "bool",
 	}
 	tc, _ := param.TypeComponentTree()
-	assert.False(t, inputTypeValidForTypeComponent(context.Background(), inputType, tc))
+	assert.False(t, inputTypeValidForTypeComponent(inputSchema, tc))
 }


### PR DESCRIPTION
After attempting to update FireFly Core to use the new version of this library, I realized the `oneOf` wasn't implemented quite correctly, given the JSON Schema library that we're using here. This PR corrects that.