### PR TITLE
Add function to get ABI constructor

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -251,6 +251,15 @@ func (a ABI) Functions() map[string]*Entry {
 	return m
 }
 
+func (a ABI) Constructor() *Entry {
+	for _, e := range a {
+		if e.Type == Constructor {
+			return e
+		}
+	}
+	return nil
+}
+
 func (a ABI) Events() map[string]*Entry {
 	m := make(map[string]*Entry)
 	for _, e := range a {

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -105,6 +105,58 @@ const sampleABI2 = `[
 	}
   ]`
 
+const sampleABI3 = `[
+	{
+		"type": "constructor",
+		"inputs": [
+		  {
+			  "name": "a",
+			  "type": "tuple",
+			  "components": [
+				  {
+					  "name": "b",
+					  "type": "uint"
+				  },
+				  {
+					  "name": "c",
+					  "type": "string[2]"
+				  },
+				  {
+					  "name": "d",
+					  "type": "bytes"
+				  }
+			  ]
+		  }
+		],
+		"outputs": []
+	},
+	{
+	  "name": "foo",
+	  "type": "function",
+	  "inputs": [
+		{
+			"name": "a",
+			"type": "tuple",
+			"components": [
+				{
+					"name": "b",
+					"type": "uint"
+				},
+				{
+					"name": "c",
+					"type": "string[2]"
+				},
+				{
+					"name": "d",
+					"type": "bytes"
+				}
+			]
+		}
+	  ],
+	  "outputs": []
+	}
+  ]`
+
 func testABI(t *testing.T, abiJSON string) (abi ABI) {
 	err := json.Unmarshal([]byte(abiJSON), &abi)
 	assert.NoError(t, err)
@@ -681,4 +733,15 @@ func TestDecodeEventBadData(t *testing.T) {
 	}
 	_, err := e.DecodeEventData([]ethtypes.HexBytes0xPrefix{}, ethtypes.MustNewHexBytes0xPrefix("0x"))
 	assert.Regexp(t, "FF22047", err)
+}
+
+func TestGetConstructor(t *testing.T) {
+	a := testABI(t, sampleABI1)
+	c := a.Constructor()
+	assert.Nil(t, c)
+
+	a = testABI(t, sampleABI3)
+	c = a.Constructor()
+	assert.Equal(t, Constructor, c.Type)
+	assert.Equal(t, 1, len(c.Inputs))
 }


### PR DESCRIPTION
Currently, constructors do not show up in the `Functions()` getter. This adds a public function to get the constructor from an ABI, which is needed by EVM connect for contract deployment.