### PR TITLE
omitempty Value and Gas for ethsigner.Transaction

### DIFF
--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -56,7 +56,7 @@ type Transaction struct {
 	MaxFeePerGas         *ethtypes.HexInteger      `json:"maxFeePerGas,omitempty"`
 	GasLimit             *ethtypes.HexInteger      `json:"gas"`
 	To                   *ethtypes.Address0xHex    `json:"to,omitempty"`
-	Value                *ethtypes.HexInteger      `json:"value"`
+	Value                *ethtypes.HexInteger      `json:"value,omitempty"`
 	Data                 ethtypes.HexBytes0xPrefix `json:"data"`
 }
 

--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -54,7 +54,7 @@ type Transaction struct {
 	GasPrice             *ethtypes.HexInteger      `json:"gasPrice,omitempty"`
 	MaxPriorityFeePerGas *ethtypes.HexInteger      `json:"maxPriorityFeePerGas,omitempty"`
 	MaxFeePerGas         *ethtypes.HexInteger      `json:"maxFeePerGas,omitempty"`
-	GasLimit             *ethtypes.HexInteger      `json:"gas"`
+	GasLimit             *ethtypes.HexInteger      `json:"gas,omitempty"` // note this is required for some methods (eth_estimateGas)
 	To                   *ethtypes.Address0xHex    `json:"to,omitempty"`
 	Value                *ethtypes.HexInteger      `json:"value,omitempty"`
 	Data                 ethtypes.HexBytes0xPrefix `json:"data"`


### PR DESCRIPTION
https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendtransaction with `value` being an optional field, this will prevent it from being serialized and passed through in JSONRPC requests when set to `nil`.

We encountered https://github.com/hyperledger/firefly-evmconnect passing `nil` `value` down to our managed signer which passed it along to the chain and received an RPC error as a result:
```
[2022-08-24T21:06:20.566Z]  INFO id=29337 method=eth_sendTransaction params=[map[data:0x48ce1dcce6ba6ce9bbd44a5a955d32e79d5f6d9d38559556a2364b60933c0ab216077c8a1cbf6f208b2b0afa8bf5b242388dca09a30d32af1b7adcc604d53f4b05d2b50c000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000002e516d5448535947415a5073424a735548746957537366344777386a364e4a62514172547274794364714d6e79736b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001471a8843524eddfda67a8769c3ac0ebf5fef87536989ae928b88fcd4fbed6866 from:0xad6d779ca7603abc0115ec7de57c89828993be19 gas:0xbb8a gasPrice:0x0 nonce:0x6 to:0xe21906c40fef96d4cee3c43bf8da724ac8783510 value:<nil>]]
...
[2022-08-24T21:06:20.566Z]  INFO Sending JSON/RPC error: Code=-32600 ID=29337 Message=''value' could not be converted to an integer: unexpected type <nil> for BigInt'
```

confirmed this works as a fix as part of testing https://github.com/hyperledger/firefly-evmconnect/pull/19.