### PR TITLE
Update info logging to include method and time

### DIFF
--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
@@ -133,6 +134,7 @@ func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRe
 		jsonInput, _ := json.Marshal(rpcReq)
 		log.L(ctx).Tracef("RPC[%s] INPUT: %s", rpcTraceID, jsonInput)
 	}
+	rpcStartTime := time.Now()
 	res, err := rc.client.R().
 		SetContext(ctx).
 		SetBody(beReq).
@@ -158,7 +160,7 @@ func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRe
 		err := fmt.Errorf(rpcRes.Message())
 		return rpcRes, err
 	}
-	log.L(ctx).Infof("RPC[%s] <-- [%d] OK", rpcTraceID, res.StatusCode())
+	log.L(ctx).Infof("RPC[%s] <-- %s [%d] OK (%.2fms)", rpcTraceID, rpcReq.Method, res.StatusCode(), float64(time.Since(rpcStartTime))/float64(time.Millisecond))
 	if rpcRes.Result == nil {
 		// We don't want a result for errors, but a null success response needs to go in there
 		rpcRes.Result = fftypes.JSONAnyPtr(fftypes.NullString)


### PR DESCRIPTION
See https://github.com/hyperledger/firefly-evmconnect/issues/26

So we have logs like this if only INFO logging is enabled:
```
RPC[2->000012346] <-- eth_getTransactionByHash [200] OK (1.43ms)
```