### PR TITLE
Fix Ethereum FFIParamValidator to allow oneOf syntax for basic types

### DIFF
--- a/pkg/ffi2abi/ffi_param_validator.go
+++ b/pkg/ffi2abi/ffi_param_validator.go
@@ -41,6 +41,22 @@ var compiledMetaSchema = jsonschema.MustCompileString("ffiParamDetails.json", `{
 						}
 					},
 					"required": [
+						"type",
+						"details"
+					]
+				},
+				{
+					"type": "object",
+					"properties": {
+						"oneOf": {
+							"type": "array"
+						},
+						"details": {
+							"$ref": "#/$defs/details"
+						}
+					},
+					"required": [
+						"oneOf",
 						"details"
 					]
 				},
@@ -63,8 +79,8 @@ var compiledMetaSchema = jsonschema.MustCompileString("ffiParamDetails.json", `{
 						}
 					},
 					"required": [
-						"details",
-						"type"
+						"type",
+						"details"
 					]
 				}
 			]
@@ -85,6 +101,22 @@ var compiledMetaSchema = jsonschema.MustCompileString("ffiParamDetails.json", `{
 						}
 					},
 					"required": [
+						"type",
+						"details"
+					]
+				},
+				{
+					"type": "object",
+					"properties": {
+						"oneOf": {
+							"type": "array"
+						},
+						"details": {
+							"$ref": "#/$defs/objectFieldDetails"
+						}
+					},
+					"required": [
+						"oneOf",
 						"details"
 					]
 				},
@@ -107,6 +139,7 @@ var compiledMetaSchema = jsonschema.MustCompileString("ffiParamDetails.json", `{
 						}
 					},
 					"required": [
+						"type",
 						"details"
 					]
 				}

--- a/pkg/ffi2abi/ffi_param_validator_test.go
+++ b/pkg/ffi2abi/ffi_param_validator_test.go
@@ -318,3 +318,32 @@ func TestInputFixedArraySizeType(t *testing.T) {
 	}`)
 	assert.NoError(t, err)
 }
+
+func TestOneOfSyntax(t *testing.T) {
+	_, err := NewTestSchema(`{
+		"type": "object",
+		"details": {
+			"type": "tuple",
+			"internalType": "struct Custom.Thing"
+		},
+		"properties": {
+			"customProp": {
+				"oneOf": [
+					{
+						"type": "string"
+					},
+					{
+						"type": "integer"
+					}
+				],
+				"details": {
+					"type": "uint256",
+					"internalType": "uint256",
+					"index": 0
+				},
+				"description": "An integer. You are recommended to use a JSON string. A JSON number can be used for values up to the safe maximum."
+			}
+		}
+	}`)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Resolves https://github.com/hyperledger/firefly-signer/issues/25

I was able to compile FireFly locally using a go.mod replace and verified that this fixes the incorrectly rejected FFI that I was seeing before.