### PR TITLE
Evaluate all FS events: SMB CIFS filesystems mounted do not notify `CREATE`

### DIFF
--- a/pkg/fswallet/fslistener.go
+++ b/pkg/fswallet/fslistener.go
@@ -58,11 +58,9 @@ func (w *fsWallet) fsListenerLoop(ctx context.Context, done func(), events chan 
 		case event, ok := <-events:
 			if ok {
 				log.L(ctx).Tracef("FSEvent [%s]: %s", event.Op, event.Name)
-				if event.Op == fsnotify.Create {
-					fi, err := os.Stat(event.Name)
-					if err == nil {
-						w.notifyNewFiles(ctx, fi)
-					}
+				fi, err := os.Stat(event.Name)
+				if err == nil {
+					w.notifyNewFiles(ctx, fi)
 				}
 			}
 		case err, ok := <-errors:


### PR DESCRIPTION
In a Linux environment with a Samba mounted CIFS filesystem, we only seem to get a notification as follows:

```
[2022-10-18T20:52:51.713Z] TRACE FSEvent [WRITE]: /.../keystore/UTC--2022-10-18T20-52-51.648Z-07686308b652040e74189f7a63a0031e6391e234 fswallet=/.../keystore
```

Currently the code only evaluates `CREATE` events, so we need to take the small overhead of the extra `stat()` and filename matching of also handling `WRITE` events.