### PR TITLE
Use RPCError as return from CallRPC() to catch error details

### DIFF
--- a/internal/rpcserver/rpcprocessor.go
+++ b/internal/rpcserver/rpcprocessor.go
@@ -86,9 +86,9 @@ func (s *rpcServer) processEthSendTransaction(ctx context.Context, rpcReq *rpcba
 		if err != nil {
 			return nil, err
 		}
-		err = s.backend.CallRPC(ctx, &txn.Nonce, "eth_getTransactionCount", &from, "pending")
-		if err != nil {
-			return rpcbackend.RPCErrorResponse(err, rpcReq.ID, rpcbackend.RPCCodeInternalError), err
+		rpcErr := s.backend.CallRPC(ctx, &txn.Nonce, "eth_getTransactionCount", &from, "pending")
+		if rpcErr != nil {
+			return rpcbackend.RPCErrorResponse(rpcErr.Error(), rpcReq.ID, rpcbackend.RPCCodeInternalError), rpcErr.Error()
 		}
 	}
 

--- a/internal/rpcserver/rpcprocessor_test.go
+++ b/internal/rpcserver/rpcprocessor_test.go
@@ -171,7 +171,7 @@ func TestSignGetNonceFail(t *testing.T) {
 	defer done()
 
 	bm := s.backend.(*rpcbackendmocks.Backend)
-	bm.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionCount", mock.Anything, "pending").Return(fmt.Errorf("pop"))
+	bm.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionCount", mock.Anything, "pending").Return(&rpcbackend.RPCError{Message: "pop"})
 
 	_, err := s.processRPC(s.ctx, &rpcbackend.RPCRequest{
 		ID:     fftypes.JSONAnyPtr("1"),

--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -82,9 +82,9 @@ func (s *rpcServer) runAPIServer() {
 func (s *rpcServer) Start() error {
 	if s.chainID < 0 {
 		var chainID ethtypes.HexInteger
-		err := s.backend.CallRPC(s.ctx, &chainID, "net_version")
-		if err != nil {
-			return i18n.WrapError(s.ctx, err, signermsgs.MsgQueryChainID)
+		rpcErr := s.backend.CallRPC(s.ctx, &chainID, "net_version")
+		if rpcErr != nil {
+			return i18n.WrapError(s.ctx, rpcErr.Error(), signermsgs.MsgQueryChainID)
 		}
 		s.chainID = chainID.BigInt().Int64()
 	}

--- a/internal/rpcserver/server_test.go
+++ b/internal/rpcserver/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/firefly-signer/mocks/ethsignermocks"
 	"github.com/hyperledger/firefly-signer/mocks/rpcbackendmocks"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
+	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -87,7 +88,7 @@ func TestStartFailChainID(t *testing.T) {
 	bm.On("CallRPC", mock.Anything, mock.Anything, "net_version").Run(func(args mock.Arguments) {
 		hi := args[1].(*ethtypes.HexInteger)
 		hi.BigInt().SetInt64(12345)
-	}).Return(fmt.Errorf("pop"))
+	}).Return(&rpcbackend.RPCError{Message: "pop"})
 
 	err := s.Start()
 	assert.Regexp(t, "pop", err)

--- a/mocks/rpcbackendmocks/backend.go
+++ b/mocks/rpcbackendmocks/backend.go
@@ -15,17 +15,19 @@ type Backend struct {
 }
 
 // CallRPC provides a mock function with given fields: ctx, result, method, params
-func (_m *Backend) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) error {
+func (_m *Backend) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *rpcbackend.RPCError {
 	var _ca []interface{}
 	_ca = append(_ca, ctx, result, method)
 	_ca = append(_ca, params...)
 	ret := _m.Called(_ca...)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string, ...interface{}) error); ok {
+	var r0 *rpcbackend.RPCError
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string, ...interface{}) *rpcbackend.RPCError); ok {
 		r0 = rf(ctx, result, method, params...)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*rpcbackend.RPCError)
+		}
 	}
 
 	return r0

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -111,9 +111,8 @@ func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method str
 	if err != nil {
 		if res.Error != nil && res.Error.Code != 0 {
 			return res.Error
-		} else {
-			return &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
 		}
+		return &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
 	}
 	err = json.Unmarshal(res.Result.Bytes(), &result)
 	if err != nil {

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -41,7 +41,7 @@ const (
 
 // Backend performs communication with a backend
 type Backend interface {
-	CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) error
+	CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError
 	SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error)
 }
 
@@ -70,6 +70,10 @@ type RPCError struct {
 	Data    fftypes.JSONAny `json:"data,omitempty"`
 }
 
+func (e *RPCError) Error() error {
+	return fmt.Errorf(e.Message)
+}
+
 type RPCResponse struct {
 	JSONRpc string           `json:"jsonrpc"`
 	ID      *fftypes.JSONAny `json:"id"`
@@ -90,7 +94,7 @@ func (rc *RPCClient) allocateRequestID(req *RPCRequest) string {
 	return reqID
 }
 
-func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) error {
+func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError {
 	req := &RPCRequest{
 		JSONRpc: "2.0",
 		Method:  method,
@@ -99,15 +103,23 @@ func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method str
 	for i, param := range params {
 		b, err := json.Marshal(param)
 		if err != nil {
-			return i18n.NewError(ctx, signermsgs.MsgInvalidParam, i, method, err)
+			return &RPCError{Code: int64(RPCCodeInvalidRequest), Message: i18n.NewError(ctx, signermsgs.MsgInvalidParam, i, method, err).Error()}
 		}
 		req.Params[i] = fftypes.JSONAnyPtrBytes(b)
 	}
 	res, err := rc.SyncRequest(ctx, req)
 	if err != nil {
-		return err
+		if res.Error != nil && res.Error.Code != 0 {
+			return res.Error
+		} else {
+			return &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
+		}
 	}
-	return json.Unmarshal(res.Result.Bytes(), &result)
+	err = json.Unmarshal(res.Result.Bytes(), &result)
+	if err != nil {
+		return &RPCError{Code: int64(RPCCodeParseError), Message: err.Error()}
+	}
+	return nil
 }
 
 // SyncRequest sends an individual RPC request to the backend (always over HTTP currently),

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -151,7 +151,7 @@ func TestSyncRPCCallOK(t *testing.T) {
 
 	var txCount ethtypes.HexInteger
 	err := rb.CallRPC(ctx, &txCount, "eth_getTransactionCount", ethtypes.MustNewAddress("0xfb075bb99f2aa4c49955bf703509a227d7a12248"), "pending")
-	assert.NoError(t, err)
+	assert.Empty(t, err)
 	assert.Equal(t, int64(0x26), txCount.BigInt().Int64())
 }
 


### PR DESCRIPTION
Signed-off-by: Jim Zhang <jim.zhang@kaleido.io>