### PR TITLE
Separate error for parse result

### DIFF
--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -81,4 +81,5 @@ var (
 	MsgNegativeUnsignedABIEncode   = ffe("FF22062", "Negative numeric value is invalid for component %s")
 	MsgRequestCanceledContext      = ffe("FF22063", "Request with id %s failed due to canceled context")
 	MsgInvalidSigner               = ffe("FF22064", "Invalid signer")
+	MsgResultParseFailed           = ffe("FF22065", "Failed to parse result (expected=%T): %s")
 )

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -124,14 +124,16 @@ func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method str
 		req.Params[i] = fftypes.JSONAnyPtrBytes(b)
 	}
 	res, err := rc.SyncRequest(ctx, req)
-	if err == nil {
-		err = json.Unmarshal(res.Result.Bytes(), &result)
-	}
 	if err != nil {
 		if res.Error != nil && res.Error.Code != 0 {
 			return res.Error
 		}
 		return &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
+	}
+	err = json.Unmarshal(res.Result.Bytes(), &result)
+	if err != nil {
+		err = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, result, err)
+		return &RPCError{Code: int64(RPCCodeParseError), Message: err.Error()}
 	}
 	return nil
 }


### PR DESCRIPTION
Correct invalid assumption in https://github.com/hyperledger/firefly-signer/pull/43 and provide a more helpful error on parse result failures.