### PR TITLE
fix: check dynamic type for tuple before decoding

### DIFF
--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -161,8 +161,6 @@ func decodeABILength(ctx context.Context, desc string, block []byte, offset int)
 	if offset+32 > len(block) {
 		return -1, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIArrayCount, desc)
 	}
-	newBlock := block[offset : offset+32]
-	fmt.Println(newBlock)
 	i := new(big.Int).SetBytes(block[offset : offset+32])
 	if i.BitLen() > 32 {
 		return -1, i18n.NewError(ctx, signermsgs.MsgABIArrayCountTooLarge, i.Text(10), desc)

--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -100,8 +100,13 @@ func decodeABIElement(ctx context.Context, breadcrumbs string, block []byte, hea
 			headStart += headOffset
 			headPosition = headStart
 		}
-		_, cv, err := walkDynamicChildArrayABIBytes(ctx, "tup", breadcrumbs, block, headStart, headPosition, component, component.tupleChildren)
-		return 32, cv, err
+
+		headBytesRead, cv, err := walkDynamicChildArrayABIBytes(ctx, "tup", breadcrumbs, block, headStart, headPosition, component, component.tupleChildren)
+		if dynamic {
+			// In the case where it's dynamic we only read one block
+			headBytesRead = 32
+		}
+		return headBytesRead, cv, err
 	default:
 		return -1, nil, i18n.NewError(ctx, signermsgs.MsgBadABITypeComponent, component.cType)
 	}

--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -346,6 +346,35 @@ func TestExampleABIDecodeTuple(t *testing.T) {
 	assert.Equal(t, big.NewInt(2414), cv.Children[0].Children[0].Children[3].Value)
 }
 
+// TestExampleABIDecodeNonDynamicTuple is responsible for testing a duple that does
+// not have any dynamic fields
+func TestExampleABIDecodeNonDynamicTuple(t *testing.T) {
+
+	f := &Entry{
+		Name: "coupon",
+		Outputs: ParameterArray{
+			{
+				Type: "tuple",
+				Name: "mystruct",
+				Components: ParameterArray{
+					{Type: "address", Name: "account"},
+					{Type: "uint256", Name: "value"},
+				},
+			},
+		},
+	}
+
+	d, _ := hex.DecodeString("" +
+		"000000000000000000000000d2d8a61d774f552301d71aa99a78aff2e4765ca7" +
+		"000000000000000000000000000000000000000000000000000000000000007b")
+
+	cv, err := f.Outputs.DecodeABIData(d, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewInt(123), cv.Children[0].Children[1].Value)
+	address, _ := cv.Children[0].Children[0].JSON()
+	assert.Equal(t, "\"d2d8a61d774f552301d71aa99a78aff2e4765ca7\"", string(address))
+}
+
 func TestExampleABIDecodeDoubleNestedTuple(t *testing.T) {
 
 	f := &Entry{

--- a/pkg/abi/abiencode.go
+++ b/pkg/abi/abiencode.go
@@ -48,7 +48,7 @@ func (cv *ComponentValue) encodeABIData(ctx context.Context, desc string) ([]byt
 	case DynamicArrayComponent:
 		return cv.encodeABIChildren(ctx, desc, true /* always dynamic */, true /* need length */)
 	case TupleComponent:
-		return cv.encodeABIChildren(ctx, desc, true /* always dynamic */, false /* no length */)
+		return cv.encodeABIChildren(ctx, desc, false /* only dynamic if the children are dynamic */, false /* no length */)
 	default:
 		return nil, false, i18n.NewError(ctx, signermsgs.MsgBadABITypeComponent, tc.cType)
 	}


### PR DESCRIPTION
This fixes https://github.com/hyperledger/firefly/issues/1323


# Context behind the fix

I took a a look at this issue and turns out that when a Solidity struct is encoded in RLP and the type in the ABI is a tuple the resulting RLP doesn't have a variable ABI length block.

For the struct in Solidity contract:
```
    struct AccountBalance {
      address account;
      uint balance;
    }
```
We get the RLP
```
000000000000000000000000d2d8a61d774f552301d71aa99a78aff2e4765ca7 // address value
000000000000000000000000000000000000000000000000000000000000007b // balance value
```

After chatting with @peterbroadhurst  we determined based on the spec what a dynamic tuple means. A tuple is dynamic if any of its elements are dynamic! In this case the tuple isn't since `address` and `uint` are not dynamic.
![image (1)](https://github.com/hyperledger/firefly-signer/assets/30461857/6b39551d-8280-4901-b2a1-dd1da694d087)

The code was always treating a TupleComponent when decoding as dynamic and decoding the ABI length. The fix is to check if the Tuple is dynamic and if so decode the ABI length, or just walk through the bytes.