### PR TITLE
Add wsbackend client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,36 @@
 run:
   tests: false
   skip-dirs:
-  - "mocks"
+    - "mocks"
+    - "ffconfig"
 linters-settings:
   golint: {}
   gocritic:
     enabled-checks: []
     disabled-checks:
       - regexpMust
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true
+  gosec:
+    excludes:
+      - G601 # Appears not to handle taking an address of a sub-structure, within a pointer to a structure within a loop. Which is valid and safe.
   goheader:
     values:
       regexp:
         COMPANY: .*
     template: |-
       Copyright © {{ YEAR }} {{ COMPANY }}
-      
+
       SPDX-License-Identifier: Apache-2.0
-      
+
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
-      
+
           http://www.apache.org/licenses/LICENSE-2.0
-      
+
       Unless required by applicable law or agreed to in writing, software
       distributed under the License is distributed on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,10 +38,9 @@ linters-settings:
       limitations under the License.
 linters:
   disable-all: false
+  disable:
+    - structcheck
   enable:
-    - bodyclose
-    - deadcode
-    - depguard
     - dogsled
     - errcheck
     - goconst
@@ -51,10 +58,7 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
-    - unparam
     - unused
-    - varcheck

--- a/config.md
+++ b/config.md
@@ -26,6 +26,7 @@ nav_order: 2
 |expectContinueTimeout|See [ExpectContinueTimeout in the Go docs](https://pkg.go.dev/net/http#Transport)|[`time.Duration`](https://pkg.go.dev/time#Duration)|`1s`
 |headers|Adds custom headers to HTTP requests|`map[string]string`|`<nil>`
 |idleTimeout|The max duration to hold a HTTP keepalive connection between calls|[`time.Duration`](https://pkg.go.dev/time#Duration)|`475ms`
+|maxConnsPerHost|The max number of connections, per unique hostname. Zero means no limit|`int`|`0`
 |maxIdleConns|The max number of idle connections to hold pooled|`int`|`100`
 |passthroughHeadersEnabled|Enable passing through the set of allowed HTTP request headers|`boolean`|`false`
 |requestTimeout|The maximum amount of time that a request is allowed to remain open|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
@@ -51,6 +52,7 @@ nav_order: 2
 |---|-----------|----|-------------|
 |count|The maximum number of times to retry|`int`|`5`
 |enabled|Enables retries|`boolean`|`false`
+|errorStatusCodeRegex|The regex that the error response status code must match to trigger retry|`string`|`<nil>`
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
 |maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 
@@ -69,6 +71,7 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
+|connectionTimeout|The amount of time to wait while establishing a connection (or auto-reconnection)|[`time.Duration`](https://pkg.go.dev/time#Duration)|`45s`
 |heartbeatInterval|The amount of time to wait between heartbeat signals on the WebSocket connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |initialConnectAttempts|The number of attempts FireFly will make to connect to the WebSocket when starting up, before failing|`int`|`5`
 |path|The WebSocket sever URL to which FireFly should connect|WebSocket URL `string`|`<nil>`

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/firefly-common v1.2.11
+	github.com/hyperledger/firefly-common v1.3.1-0.20231003142556-37246a8c5e72
 	github.com/karlseguin/ccache v2.0.3+incompatible
 	github.com/pelletier/go-toml v1.9.5
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.2
@@ -69,7 +69,7 @@ require (
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect; indirectå
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hyperledger/firefly-common v1.2.11 h1:ePDHJtorKE6ss8PtoPlyqLb+cB0TDB7ziM85Gtyerqs=
-github.com/hyperledger/firefly-common v1.2.11/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
+github.com/hyperledger/firefly-common v1.3.1-0.20231003142556-37246a8c5e72 h1:l/Yo3woV2pih5EVmUHFwXr0LVr0twtXCVAdJAWInf5Q=
+github.com/hyperledger/firefly-common v1.3.1-0.20231003142556-37246a8c5e72/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=

--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -83,4 +83,6 @@ var (
 	MsgInvalidSigner               = ffe("FF22064", "Invalid signer")
 	MsgResultParseFailed           = ffe("FF22065", "Failed to parse result (expected=%T): %s")
 	MsgSubscribeResponseInvalid    = ffe("FF22066", "Subscription response invalid")
+	MsgWebSocketReconnected        = ffe("FF22067", "WebSocket reconnected during JSON/RPC call")
+	MsgContextCancelledWSConnect   = ffe("FF22068", "Context canceled while connecting WebSocket")
 )

--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -82,4 +82,5 @@ var (
 	MsgRequestCanceledContext      = ffe("FF22063", "Request with id %s failed due to canceled context")
 	MsgInvalidSigner               = ffe("FF22064", "Invalid signer")
 	MsgResultParseFailed           = ffe("FF22065", "Failed to parse result (expected=%T): %s")
+	MsgSubscribeResponseInvalid    = ffe("FF22066", "Subscription response invalid")
 )

--- a/pkg/ethereum/ethereum.go
+++ b/pkg/ethereum/ethereum.go
@@ -25,17 +25,17 @@ import (
 
 // txReceiptJSONRPC is the receipt obtained over JSON/RPC from the ethereum client, with gas used, logs and contract address
 type TXReceiptJSONRPC struct {
-	BlockHash         ethtypes.HexBytes0xPrefix `json:"blockHash"`
-	BlockNumber       *ethtypes.HexInteger      `json:"blockNumber"`
-	ContractAddress   *ethtypes.Address0xHex    `json:"contractAddress"`
-	CumulativeGasUsed *ethtypes.HexInteger      `json:"cumulativeGasUsed"`
-	From              *ethtypes.Address0xHex    `json:"from"`
-	GasUsed           *ethtypes.HexInteger      `json:"gasUsed"`
-	Logs              []*LogJSONRPC             `json:"logs"`
-	Status            *ethtypes.HexInteger      `json:"status"`
-	To                *ethtypes.Address0xHex    `json:"to"`
-	TransactionHash   ethtypes.HexBytes0xPrefix `json:"transactionHash"`
-	TransactionIndex  *ethtypes.HexInteger      `json:"transactionIndex"`
+	BlockHash         ethtypes.HexBytes0xPrefix     `json:"blockHash"`
+	BlockNumber       *ethtypes.HexInteger          `json:"blockNumber"`
+	ContractAddress   *ethtypes.AddressWithChecksum `json:"contractAddress"`
+	CumulativeGasUsed *ethtypes.HexInteger          `json:"cumulativeGasUsed"`
+	From              *ethtypes.AddressWithChecksum `json:"from"`
+	GasUsed           *ethtypes.HexInteger          `json:"gasUsed"`
+	Logs              []*LogJSONRPC                 `json:"logs"`
+	Status            *ethtypes.HexInteger          `json:"status"`
+	To                *ethtypes.AddressWithChecksum `json:"to"`
+	TransactionHash   ethtypes.HexBytes0xPrefix     `json:"transactionHash"`
+	TransactionIndex  *ethtypes.HexInteger          `json:"transactionIndex"`
 }
 
 // receiptExtraInfo is the version of the receipt we store under the TX.
@@ -43,33 +43,33 @@ type TXReceiptJSONRPC struct {
 // - We omit fields already in the standardized cross-blockchain section
 // - We format numbers as decimals
 type ReceiptExtraInfo struct {
-	ContractAddress   *ethtypes.Address0xHex `json:"contractAddress"`
-	CumulativeGasUsed *fftypes.FFBigInt      `json:"cumulativeGasUsed"`
-	From              *ethtypes.Address0xHex `json:"from"`
-	To                *ethtypes.Address0xHex `json:"to"`
-	GasUsed           *fftypes.FFBigInt      `json:"gasUsed"`
-	Status            *fftypes.FFBigInt      `json:"status"`
-	ErrorMessage      *string                `json:"errorMessage"`
+	ContractAddress   *ethtypes.AddressWithChecksum `json:"contractAddress"`
+	CumulativeGasUsed *fftypes.FFBigInt             `json:"cumulativeGasUsed"`
+	From              *ethtypes.AddressWithChecksum `json:"from"`
+	To                *ethtypes.AddressWithChecksum `json:"to"`
+	GasUsed           *fftypes.FFBigInt             `json:"gasUsed"`
+	Status            *fftypes.FFBigInt             `json:"status"`
+	ErrorMessage      *string                       `json:"errorMessage"`
 }
 
 // txInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data
 type TXInfoJSONRPC struct {
-	BlockHash        ethtypes.HexBytes0xPrefix `json:"blockHash"`   // null if pending
-	BlockNumber      *ethtypes.HexInteger      `json:"blockNumber"` // null if pending
-	From             *ethtypes.Address0xHex    `json:"from"`
-	ChainID          *ethtypes.HexInteger      `json:"chainID"`
-	Gas              *ethtypes.HexInteger      `json:"gas"`
-	GasPrice         *ethtypes.HexInteger      `json:"gasPrice"`
-	Hash             ethtypes.HexBytes0xPrefix `json:"hash"`
-	Input            ethtypes.HexBytes0xPrefix `json:"input"`
-	Nonce            *ethtypes.HexInteger      `json:"nonce"`
-	R                *ethtypes.HexInteger      `json:"r"`
-	S                *ethtypes.HexInteger      `json:"s"`
-	To               *ethtypes.Address0xHex    `json:"to"`
-	TransactionIndex *ethtypes.HexInteger      `json:"transactionIndex"` // null if pending
-	Type             *ethtypes.HexInteger      `json:"type"`
-	V                *ethtypes.HexInteger      `json:"v"`
-	Value            *ethtypes.HexInteger      `json:"value"`
+	BlockHash        ethtypes.HexBytes0xPrefix     `json:"blockHash"`   // null if pending
+	BlockNumber      *ethtypes.HexInteger          `json:"blockNumber"` // null if pending
+	From             *ethtypes.AddressWithChecksum `json:"from"`
+	ChainID          *ethtypes.HexInteger          `json:"chainID"`
+	Gas              *ethtypes.HexInteger          `json:"gas"`
+	GasPrice         *ethtypes.HexInteger          `json:"gasPrice"`
+	Hash             ethtypes.HexBytes0xPrefix     `json:"hash"`
+	Input            ethtypes.HexBytes0xPrefix     `json:"input"`
+	Nonce            *ethtypes.HexInteger          `json:"nonce"`
+	R                *ethtypes.HexInteger          `json:"r"`
+	S                *ethtypes.HexInteger          `json:"s"`
+	To               *ethtypes.AddressWithChecksum `json:"to"`
+	TransactionIndex *ethtypes.HexInteger          `json:"transactionIndex"` // null if pending
+	Type             *ethtypes.HexInteger          `json:"type"`
+	V                *ethtypes.HexInteger          `json:"v"`
+	Value            *ethtypes.HexInteger          `json:"value"`
 }
 
 func (t *TXInfoJSONRPC) Cost() *big.Int {

--- a/pkg/ethereum/ethereum.go
+++ b/pkg/ethereum/ethereum.go
@@ -1,0 +1,96 @@
+// Copyright © 2023 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethereum
+
+import (
+	"math/big"
+
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
+)
+
+// txReceiptJSONRPC is the receipt obtained over JSON/RPC from the ethereum client, with gas used, logs and contract address
+type TXReceiptJSONRPC struct {
+	BlockHash         ethtypes.HexBytes0xPrefix `json:"blockHash"`
+	BlockNumber       *ethtypes.HexInteger      `json:"blockNumber"`
+	ContractAddress   *ethtypes.Address0xHex    `json:"contractAddress"`
+	CumulativeGasUsed *ethtypes.HexInteger      `json:"cumulativeGasUsed"`
+	From              *ethtypes.Address0xHex    `json:"from"`
+	GasUsed           *ethtypes.HexInteger      `json:"gasUsed"`
+	Logs              []*LogJSONRPC             `json:"logs"`
+	Status            *ethtypes.HexInteger      `json:"status"`
+	To                *ethtypes.Address0xHex    `json:"to"`
+	TransactionHash   ethtypes.HexBytes0xPrefix `json:"transactionHash"`
+	TransactionIndex  *ethtypes.HexInteger      `json:"transactionIndex"`
+}
+
+// receiptExtraInfo is the version of the receipt we store under the TX.
+// - We omit the full logs from the JSON/RPC
+// - We omit fields already in the standardized cross-blockchain section
+// - We format numbers as decimals
+type ReceiptExtraInfo struct {
+	ContractAddress   *ethtypes.Address0xHex `json:"contractAddress"`
+	CumulativeGasUsed *fftypes.FFBigInt      `json:"cumulativeGasUsed"`
+	From              *ethtypes.Address0xHex `json:"from"`
+	To                *ethtypes.Address0xHex `json:"to"`
+	GasUsed           *fftypes.FFBigInt      `json:"gasUsed"`
+	Status            *fftypes.FFBigInt      `json:"status"`
+	ErrorMessage      *string                `json:"errorMessage"`
+}
+
+// txInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data
+type TXInfoJSONRPC struct {
+	BlockHash        ethtypes.HexBytes0xPrefix `json:"blockHash"`   // null if pending
+	BlockNumber      *ethtypes.HexInteger      `json:"blockNumber"` // null if pending
+	From             *ethtypes.Address0xHex    `json:"from"`
+	ChainID          *ethtypes.HexInteger      `json:"chainID"`
+	Gas              *ethtypes.HexInteger      `json:"gas"`
+	GasPrice         *ethtypes.HexInteger      `json:"gasPrice"`
+	Hash             ethtypes.HexBytes0xPrefix `json:"hash"`
+	Input            ethtypes.HexBytes0xPrefix `json:"input"`
+	Nonce            *ethtypes.HexInteger      `json:"nonce"`
+	R                *ethtypes.HexInteger      `json:"r"`
+	S                *ethtypes.HexInteger      `json:"s"`
+	To               *ethtypes.Address0xHex    `json:"to"`
+	TransactionIndex *ethtypes.HexInteger      `json:"transactionIndex"` // null if pending
+	Type             *ethtypes.HexInteger      `json:"type"`
+	V                *ethtypes.HexInteger      `json:"v"`
+	Value            *ethtypes.HexInteger      `json:"value"`
+}
+
+func (t *TXInfoJSONRPC) Cost() *big.Int {
+	return big.NewInt(0).Mul(t.GasPrice.BigInt(), t.Gas.BigInt())
+}
+
+type LogFilterJSONRPC struct {
+	FromBlock *ethtypes.HexInteger          `json:"fromBlock,omitempty"`
+	ToBlock   *ethtypes.HexInteger          `json:"toBlock,omitempty"`
+	Address   *ethtypes.Address0xHex        `json:"address,omitempty"`
+	Topics    [][]ethtypes.HexBytes0xPrefix `json:"topics,omitempty"`
+}
+
+type LogJSONRPC struct {
+	Removed          bool                        `json:"removed"`
+	LogIndex         *ethtypes.HexInteger        `json:"logIndex"`
+	TransactionIndex *ethtypes.HexInteger        `json:"transactionIndex"`
+	BlockNumber      *ethtypes.HexInteger        `json:"blockNumber"`
+	TransactionHash  ethtypes.HexBytes0xPrefix   `json:"transactionHash"`
+	BlockHash        ethtypes.HexBytes0xPrefix   `json:"blockHash"`
+	Address          *ethtypes.Address0xHex      `json:"address"`
+	Data             ethtypes.HexBytes0xPrefix   `json:"data"`
+	Topics           []ethtypes.HexBytes0xPrefix `json:"topics"`
+}

--- a/pkg/ethtypes/hexinteger.go
+++ b/pkg/ethtypes/hexinteger.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -17,9 +17,12 @@
 package ethtypes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
+
+	"github.com/hyperledger/firefly-common/pkg/i18n"
 )
 
 // HexInteger is a positive integer - serializes to JSON as an 0x hex string (no leading zeros), and parses flexibly depending on the prefix (so 0x for hex, or base 10 for plain string / float64)
@@ -62,10 +65,37 @@ func (h *HexInteger) BigInt() *big.Int {
 	return (*big.Int)(h)
 }
 
+func (h *HexInteger) Uint64() uint64 {
+	return h.BigInt().Uint64()
+}
+
+func (h *HexInteger) Int64() int64 {
+	return h.BigInt().Int64()
+}
+
+func NewHexIntegerU64(i uint64) *HexInteger {
+	return (*HexInteger)(big.NewInt(0).SetUint64(i))
+}
+
 func NewHexInteger64(i int64) *HexInteger {
 	return (*HexInteger)(big.NewInt(i))
 }
 
 func NewHexInteger(i *big.Int) *HexInteger {
 	return (*HexInteger)(i)
+}
+
+func (h *HexInteger) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case nil:
+		return nil
+	case int64:
+		*h = *NewHexInteger64(src)
+		return nil
+	case uint64:
+		*h = *NewHexIntegerU64(src)
+		return nil
+	default:
+		return i18n.NewError(context.Background(), i18n.MsgTypeRestoreFailed, src, h)
+	}
 }

--- a/pkg/ethtypes/hexinteger_test.go
+++ b/pkg/ethtypes/hexinteger_test.go
@@ -49,6 +49,8 @@ func TestHexIntegerOk(t *testing.T) {
 	assert.Nil(t, testStruct.I4)
 	assert.Equal(t, int64(0), testStruct.I4.BigInt().Int64()) // BigInt() safe on nils
 	assert.Nil(t, testStruct.I5)
+	assert.Equal(t, int64(12345), testStruct.I3.Int64())
+	assert.Equal(t, uint64(12345), testStruct.I3.Uint64())
 
 	jsonSerialized, err := json.Marshal(&testStruct)
 	assert.JSONEq(t, `{
@@ -121,4 +123,17 @@ func TestHexIntConstructors(t *testing.T) {
 	assert.Equal(t, int64(12345), NewHexInteger(big.NewInt(12345)).BigInt().Int64())
 	assert.Equal(t, "0x0", NewHexInteger(big.NewInt(0)).String())
 	assert.Equal(t, "0x1", NewHexInteger(big.NewInt(1)).String())
+	assert.Equal(t, "0x1", NewHexIntegerU64(1).String())
+}
+
+func TestScan(t *testing.T) {
+	i := &HexInteger{}
+	err := i.Scan(false)
+	err = i.Scan(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x0", i.String())
+	i.Scan(int64(5555))
+	assert.Equal(t, "0x15b3", i.String())
+	i.Scan(uint64(9999))
+	assert.Equal(t, "0x270f", i.String())
 }

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -39,13 +39,13 @@ const (
 	RPCCodeInternalError  RPCCode = -32603
 )
 
-type RPCCaller interface {
+type RPC interface {
 	CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError
 }
 
 // Backend performs communication with a backend
 type Backend interface {
-	RPCCaller
+	RPC
 	SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error)
 }
 

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-signer/internal/signermsgs"
-	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,9 +39,13 @@ const (
 	RPCCodeInternalError  RPCCode = -32603
 )
 
+type RPCCaller interface {
+	CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError
+}
+
 // Backend performs communication with a backend
 type Backend interface {
-	CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError
+	RPCCaller
 	SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error)
 }
 
@@ -81,18 +84,6 @@ type RPCRequest struct {
 	Params  []*fftypes.JSONAny `json:"params,omitempty"`
 }
 
-type RPCSubscriptionRequest struct {
-	JSONRpc string                 `json:"jsonrpc"`
-	ID      *fftypes.JSONAny       `json:"id"`
-	Method  string                 `json:"method"`
-	Params  *RPCSubscriptionParams `json:"params"`
-}
-
-type RPCSubscriptionParams struct {
-	Subscription ethtypes.HexBytes0xPrefix `json:"subscription"`
-	Result       *fftypes.JSONAny          `json:"result"`
-}
-
 type RPCError struct {
 	Code    int64           `json:"code"`
 	Message string          `json:"message"`
@@ -103,11 +94,18 @@ func (e *RPCError) Error() error {
 	return fmt.Errorf(e.Message)
 }
 
+func (e *RPCError) String() string {
+	return e.Message
+}
+
 type RPCResponse struct {
 	JSONRpc string           `json:"jsonrpc"`
 	ID      *fftypes.JSONAny `json:"id"`
 	Result  *fftypes.JSONAny `json:"result,omitempty"`
 	Error   *RPCError        `json:"error,omitempty"`
+	// Only for subscription notifications
+	Method string           `json:"method,omitempty"`
+	Params *fftypes.JSONAny `json:"params,omitempty"`
 }
 
 func (r *RPCResponse) Message() string {
@@ -124,19 +122,11 @@ func (rc *RPCClient) allocateRequestID(req *RPCRequest) string {
 }
 
 func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError {
-	req := &RPCRequest{
-		JSONRpc: "2.0",
-		Method:  method,
-		Params:  make([]*fftypes.JSONAny, len(params)),
+	rpcReq, rpcErr := buildRequest(ctx, method, params)
+	if rpcErr != nil {
+		return rpcErr
 	}
-	for i, param := range params {
-		b, err := json.Marshal(param)
-		if err != nil {
-			return &RPCError{Code: int64(RPCCodeInvalidRequest), Message: i18n.NewError(ctx, signermsgs.MsgInvalidParam, i, method, err).Error()}
-		}
-		req.Params[i] = fftypes.JSONAnyPtrBytes(b)
-	}
-	res, err := rc.SyncRequest(ctx, req)
+	res, err := rc.SyncRequest(ctx, rpcReq)
 	if err != nil {
 		if res.Error != nil && res.Error.Code != 0 {
 			return res.Error
@@ -230,4 +220,24 @@ func RPCErrorResponse(err error, id *fftypes.JSONAny, code RPCCode) *RPCResponse
 			Message: err.Error(),
 		},
 	}
+}
+
+func NewRPCError(ctx context.Context, code RPCCode, msg i18n.ErrorMessageKey, inserts ...interface{}) *RPCError {
+	return &RPCError{Code: int64(code), Message: i18n.NewError(ctx, msg, inserts...).Error()}
+}
+
+func buildRequest(ctx context.Context, method string, params []interface{}) (*RPCRequest, *RPCError) {
+	req := &RPCRequest{
+		JSONRpc: "2.0",
+		Method:  method,
+		Params:  make([]*fftypes.JSONAny, len(params)),
+	}
+	for i, param := range params {
+		b, err := json.Marshal(param)
+		if err != nil {
+			return nil, NewRPCError(ctx, RPCCodeInvalidRequest, signermsgs.MsgInvalidParam, i, method, err)
+		}
+		req.Params[i] = fftypes.JSONAnyPtrBytes(b)
+	}
+	return req, nil
 }

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-signer/internal/signermsgs"
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/sirupsen/logrus"
 )
 
@@ -78,6 +79,18 @@ type RPCRequest struct {
 	ID      *fftypes.JSONAny   `json:"id"`
 	Method  string             `json:"method"`
 	Params  []*fftypes.JSONAny `json:"params,omitempty"`
+}
+
+type RPCSubscriptionRequest struct {
+	JSONRpc string                 `json:"jsonrpc"`
+	ID      *fftypes.JSONAny       `json:"id"`
+	Method  string                 `json:"method"`
+	Params  *RPCSubscriptionParams `json:"params"`
+}
+
+type RPCSubscriptionParams struct {
+	Subscription ethtypes.HexBytes0xPrefix `json:"subscription"`
+	Result       *fftypes.JSONAny          `json:"result"`
 }
 
 type RPCError struct {

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -31,8 +31,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// WSBackend performs communication with a backend
-type WSBackend interface {
+// RPCCallAndSubscribe performs communication over a websocket with a JSON/RPC endpoint
+//
+// - Manages websocket connect/reconnect with keepalive etc.
+// - Manages subscriptions with a local ID, so they re-established automatically after reconnect
+// - Allows synchronous exchange over the WebSocket so you don't have to maintain a separate HTTP connection too
+type RPCCallAndSubscribe interface {
 	RPCCaller
 	Subscribe(ctx context.Context, params ...interface{}) (sub Subscription, error *RPCError)
 	Subscriptions() []Subscription
@@ -42,7 +46,7 @@ type WSBackend interface {
 }
 
 // NewRPCClient Constructor
-func NewWSRPCClient(wsConf *wsclient.WSConfig) WSBackend {
+func NewWSRPCClient(wsConf *wsclient.WSConfig) RPCCallAndSubscribe {
 	return &wsRPCClient{
 		wsConf:             *wsConf,
 		calls:              make(map[string]chan *RPCResponse),

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -21,20 +21,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"sync/atomic"
+	"time"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-common/pkg/wsclient"
 	"github.com/hyperledger/firefly-signer/internal/signermsgs"
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/sirupsen/logrus"
 )
 
 // WSBackend performs communication with a backend
 type WSBackend interface {
-	CallRPC(ctx context.Context, method string, params ...interface{}) (id string, rpcErr *RPCError)
-	Subscribe(ctx context.Context, subChannel chan *RPCSubscriptionRequest, params ...interface{}) (error *RPCError)
+	RPCCaller
+	Subscribe(ctx context.Context, params ...interface{}) (sub Subscription, error *RPCError)
 	UnsubscribeAll(ctx context.Context) (error *RPCError)
 	Connect(ctx context.Context) error
 	Close()
@@ -42,149 +43,324 @@ type WSBackend interface {
 
 // NewRPCClient Constructor
 func NewWSRPCClient(client wsclient.WSClient) WSBackend {
-	return &WSRPCClient{
-		client:               client,
-		subscriptions:        make(map[string]chan *RPCSubscriptionRequest),
-		pendingSubscriptions: make(map[string]chan *RPCSubscriptionRequest),
+	return &wsRPCClient{
+		client:        client,
+		calls:         make(map[string]chan *RPCResponse),
+		pendingSubs:   make(map[string]chan *newSubResponse),
+		subscriptions: make(map[string]*sub),
 	}
 }
 
-type WSRPCClient struct {
-	client               wsclient.WSClient
-	requestCounter       int64
-	subscriptions        map[string]chan *RPCSubscriptionRequest
-	pendingSubscriptions map[string]chan *RPCSubscriptionRequest
-	pendingSubMutex      sync.Mutex
-	subMutex             sync.Mutex
+type Subscription interface {
+	ID() string
+	Notifications() chan *RPCSubscriptionNotification
+	Unsubscribe(ctx context.Context) *RPCError
 }
 
-func (rc *WSRPCClient) Connect(ctx context.Context) error {
+type RPCSubscriptionNotification struct {
+	Subscription Subscription
+	Result       *fftypes.JSONAny
+}
+
+type wsRPCClient struct {
+	mux            sync.Mutex
+	client         wsclient.WSClient
+	requestCounter int64
+	calls          map[string]chan *RPCResponse
+	pendingSubs    map[string]chan *newSubResponse
+	subscriptions  map[string]*sub
+}
+
+type sub struct {
+	rc             *wsRPCClient
+	ctx            context.Context
+	cancelCtx      context.CancelFunc
+	subscriptionID string
+	notifications  chan *RPCSubscriptionNotification
+}
+
+type newSubResponse struct {
+	s      *sub
+	rpcErr *RPCError
+}
+
+func (rc *wsRPCClient) Connect(ctx context.Context) error {
 	if err := rc.client.Connect(); err != nil {
 		return err
 	}
-	go rc.receiveLoop(ctx)
+	go rc.receiveLoop(log.WithLogField(ctx, "role", "rpc_websocket"))
 	return nil
 }
 
-func (rc *WSRPCClient) Close() {
+func (rc *wsRPCClient) Close() {
 	rc.client.Close()
 }
 
-func (rc *WSRPCClient) allocateRequestID(req *RPCRequest) string {
-	reqID := fmt.Sprintf(`%.9d`, atomic.AddInt64(&rc.requestCounter, 1))
+func (rc *wsRPCClient) addInflightRequest(req *RPCRequest) (string, chan *RPCResponse) {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	rc.requestCounter++
+	reqID := fmt.Sprintf("%.9d", rc.requestCounter)
 	req.ID = fftypes.JSONAnyPtr(`"` + reqID + `"`)
-	return reqID
+	resChl := make(chan *RPCResponse, 1)
+	rc.calls[reqID] = resChl
+	return reqID, resChl
 }
 
-func (rc *WSRPCClient) Subscribe(ctx context.Context, subChannel chan *RPCSubscriptionRequest, params ...interface{}) (error *RPCError) {
-	rc.pendingSubMutex.Lock()
-	defer rc.pendingSubMutex.Unlock()
-	reqID, err := rc.CallRPC(ctx, "eth_subscribe", params...)
-	if err != nil {
-		return err
+func (rc *wsRPCClient) addInflightSub(req *RPCRequest) (string, chan *newSubResponse) {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	rc.requestCounter++
+	reqID := fmt.Sprintf("%.9d", rc.requestCounter)
+	req.ID = fftypes.JSONAnyPtr(`"` + reqID + `"`)
+	resChl := make(chan *newSubResponse, 1)
+	rc.pendingSubs[reqID] = resChl
+	return reqID, resChl
+}
+
+func (rc *wsRPCClient) popInflight(rpcID string) (chan *newSubResponse, chan *RPCResponse) {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	inflightSub, ok := rc.pendingSubs[rpcID]
+	if ok {
+		delete(rc.pendingSubs, rpcID)
+		return inflightSub, nil
 	}
-	rc.pendingSubscriptions[reqID] = subChannel
+	inflightCall, ok := rc.calls[rpcID]
+	if ok {
+		delete(rc.calls, rpcID)
+		return nil, inflightCall
+	}
+	return nil, nil
+}
+
+func (rc *wsRPCClient) addSubscription(s *sub) {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	rc.subscriptions[s.subscriptionID] = s
+}
+
+func (rc *wsRPCClient) removeSubscription(s *sub) {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	delete(rc.subscriptions, s.subscriptionID)
+}
+
+func (rc *wsRPCClient) getSubscription(subscriptionID string) *sub {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	return rc.subscriptions[subscriptionID]
+}
+
+func (rc *wsRPCClient) getAllSubscriptions() []*sub {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	subs := make([]*sub, 0, len(rc.subscriptions))
+	for _, s := range rc.subscriptions {
+		subs = append(subs, s)
+	}
+	return subs
+}
+
+func (rc *wsRPCClient) removeInflightRequest(reqID string) {
+	rc.mux.Lock()
+	defer rc.mux.Unlock()
+	delete(rc.calls, reqID)
+}
+
+func (rc *wsRPCClient) Subscribe(ctx context.Context, params ...interface{}) (sub Subscription, error *RPCError) {
+
+	// We can't just use RPCCall here, because we have to intercept the response differently on the routine
+	rpcReq, rpcErr := buildRequest(ctx, "eth_subscribe", params)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	reqID, resChannel := rc.addInflightSub(rpcReq)
+	defer rc.removeInflightRequest(reqID)
+
+	if rpcErr = rc.sendRPC(ctx, reqID, rpcReq); rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	select {
+	case nsr := <-resChannel:
+		return nsr.s, nsr.rpcErr
+	case <-ctx.Done():
+		return nil, NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgRequestCanceledContext, reqID)
+	}
+}
+
+func (s *sub) ID() string {
+	return s.subscriptionID
+}
+
+func (s *sub) Notifications() chan *RPCSubscriptionNotification {
+	return s.notifications
+}
+
+func (s *sub) Unsubscribe(ctx context.Context) *RPCError {
+	var unsubscribed bool
+	s.cancelCtx() // we unblock the receiver if it was previously trying to dispatch to this subscription, before invoking unsubscribe
+	s.rc.removeSubscription(s)
+	rpcErr := s.rc.CallRPC(ctx, &unsubscribed, "eth_unsubscribe", s.subscriptionID)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if !unsubscribed {
+		log.L(ctx).Warnf("Server returned false for unsubscribe on '%s'", s.subscriptionID)
+	}
+	close(s.notifications)
 	return nil
 }
 
-func (rc *WSRPCClient) UnsubscribeAll(ctx context.Context) (error *RPCError) {
-	rc.subMutex.Lock()
-	for subID, subChan := range rc.subscriptions {
-		close(subChan)
-		delete(rc.subscriptions, subID)
-		_, err := rc.CallRPC(ctx, "eth_unsubscribe", subID)
-		if err != nil {
-			return err
+func (rc *wsRPCClient) UnsubscribeAll(ctx context.Context) (lastErr *RPCError) {
+	for _, s := range rc.getAllSubscriptions() {
+		if lastErr = s.Unsubscribe(ctx); lastErr != nil {
+			log.L(ctx).Errorf("Failed to unsubscribe %s: %s", s.subscriptionID, lastErr)
 		}
 	}
-	return nil
+	return lastErr
 }
 
-func (rc *WSRPCClient) CallRPC(ctx context.Context, method string, params ...interface{}) (id string, rpcErr *RPCError) {
-	req := &RPCRequest{
-		JSONRpc: "2.0",
-		Method:  method,
-		Params:  make([]*fftypes.JSONAny, len(params)),
-	}
-	for i, param := range params {
-		b, err := json.Marshal(param)
-		if err != nil {
-			return "", &RPCError{Code: int64(RPCCodeInvalidRequest), Message: i18n.NewError(ctx, signermsgs.MsgInvalidParam, i, method, err).Error()}
-		}
-		req.Params[i] = fftypes.JSONAnyPtrBytes(b)
-	}
-	reqID, err := rc.request(ctx, req)
-	if err != nil {
-		return reqID, &RPCError{Code: int64(RPCCodeInvalidRequest), Message: i18n.NewError(ctx, signermsgs.MsgInvalidParam, 0, method, err).Error()}
-	}
-	return reqID, nil
-}
-
-func (rc *WSRPCClient) request(ctx context.Context, rpcReq *RPCRequest) (id string, err error) {
-	// We always set the back-end request ID - as we need to support requests coming in from
-	// multiple concurrent clients on our front-end that might use clashing IDs.
-	reqID := rc.allocateRequestID(rpcReq)
+func (rc *wsRPCClient) sendRPC(ctx context.Context, reqID string, rpcReq *RPCRequest) *RPCError {
 	jsonInput, _ := json.Marshal(rpcReq)
-
 	log.L(ctx).Debugf("RPC[%s] --> %s", reqID, rpcReq.Method)
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		log.L(ctx).Tracef("RPC[%s] INPUT: %s", reqID, jsonInput)
 	}
-	err = rc.client.Send(ctx, jsonInput)
-
-	// Restore the original ID
+	err := rc.client.Send(ctx, jsonInput)
 	if err != nil {
-		err := i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, err)
+		rpcErr := NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgRPCRequestFailed, err)
 		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, err)
-		return reqID, err
+		return rpcErr
 	}
-	return reqID, nil
+	return nil
 }
 
-func (rc *WSRPCClient) receiveLoop(ctx context.Context) {
+func (rc *wsRPCClient) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError {
+	rpcReq, rpcErr := buildRequest(ctx, method, params)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	reqID, resChannel := rc.addInflightRequest(rpcReq)
+	defer rc.removeInflightRequest(reqID)
+
+	rpcStartTime := time.Now()
+	if rpcErr = rc.sendRPC(ctx, reqID, rpcReq); rpcErr != nil {
+		return rpcErr
+	}
+
+	var rpcRes *RPCResponse
+	select {
+	case rpcRes = <-resChannel:
+	case <-ctx.Done():
+		rpcErr := NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgRequestCanceledContext, reqID)
+		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, rpcErr.Error())
+		return rpcErr
+	}
+	if rpcRes.Error != nil && rpcRes.Error.Code != 0 {
+		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, rpcRes.Message())
+		return rpcRes.Error
+	}
+	log.L(ctx).Infof("RPC[%s] <-- %s OK (%.2fms)", reqID, rpcReq.Method, float64(time.Since(rpcStartTime))/float64(time.Millisecond))
+	if rpcRes.Result == nil {
+		// We don't want a result for errors, but a null success response needs to go in there
+		rpcRes.Result = fftypes.JSONAnyPtr(fftypes.NullString)
+	}
+	if err := json.Unmarshal(rpcRes.Result.Bytes(), &result); err != nil {
+		err = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, result, err)
+		return &RPCError{Code: int64(RPCCodeParseError), Message: err.Error()}
+	}
+	return nil
+}
+
+func (rc *wsRPCClient) handleSubscriptionNotification(ctx context.Context, rpcRes *RPCResponse) {
+	type rpcSubscriptionParams struct {
+		Subscription ethtypes.HexBytes0xPrefix `json:"subscription"`
+		Result       *fftypes.JSONAny          `json:"result,omitempty"`
+	}
+	var subParams rpcSubscriptionParams
+	if rpcRes.Params != nil {
+		_ = json.Unmarshal(rpcRes.Params.Bytes(), &subParams)
+	}
+	if len(subParams.Subscription) == 0 {
+		log.L(ctx).Warnf("RPC[%s] <-- Unable to extract subscription id from notification: %s", rpcRes.ID.AsString(), rpcRes.Params)
+		return
+	}
+
+	sub := rc.getSubscription(subParams.Subscription.String())
+	if sub == nil {
+		log.L(ctx).Warnf("RPC[%s] <-- Notification for unknown subscription '%s'", rpcRes.ID.AsString(), subParams.Subscription)
+		return
+	}
+
+	// This is a notification that should match an active subscription
+	select {
+	case sub.notifications <- &RPCSubscriptionNotification{
+		Subscription: sub,
+		Result:       subParams.Result,
+	}:
+	case <-sub.ctx.Done():
+		// The subscription has been unsubscribed, or we're closing
+		log.L(ctx).Warnf("RPC[%s] <-- Received subscription event after unsubscribe/close %s", rpcRes.ID.AsString(), sub.subscriptionID)
+	}
+}
+
+func (rc *wsRPCClient) handleSubscriptionConfirm(ctx context.Context, rpcRes *RPCResponse, inflightSubscribe chan *newSubResponse) {
+	if rpcRes.Error != nil && rpcRes.Error.Code != 0 {
+		inflightSubscribe <- &newSubResponse{
+			rpcErr: rpcRes.Error,
+		}
+		return
+	}
+	var subscriptionID ethtypes.HexBytes0xPrefix
+	if rpcRes.Result != nil {
+		_ = json.Unmarshal(rpcRes.Result.Bytes(), &subscriptionID)
+	}
+	if len(subscriptionID) == 0 {
+		log.L(ctx).Warnf("RPC[%s] <-- Unable to extract subscription id from eth_subscribe response: %s", rpcRes.ID.AsString(), rpcRes.Params)
+		inflightSubscribe <- &newSubResponse{
+			rpcErr: NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgSubscribeResponseInvalid),
+		}
+		return
+	}
+	s := &sub{
+		rc:             rc,
+		subscriptionID: subscriptionID.String(),
+		notifications:  make(chan *RPCSubscriptionNotification), // blocking channel for these, but Unsubscribe will unblock by cancelling ctx
+	}
+	s.ctx, s.cancelCtx = context.WithCancel(ctx)
+	rc.addSubscription(s)
+	inflightSubscribe <- &newSubResponse{
+		s: s,
+	}
+}
+
+func (rc *wsRPCClient) receiveLoop(ctx context.Context) {
 	for {
 		bytes, ok := <-rc.client.Receive()
 		if !ok {
+			log.L(ctx).Debugf("WebSocket closed")
 			return
 		}
-		res := &RPCResponse{}
-		if err := json.Unmarshal(bytes, res); err != nil {
-			log.L(ctx).Errorf("RPC <-- ERROR: %s", err)
-		}
-		// If it doesn't have a result, it might be a request instead
-		if res == nil || res.Result == nil || res.Result.String() == "" {
-			req := &RPCSubscriptionRequest{}
-			if err := json.Unmarshal(bytes, req); err != nil {
-				log.L(ctx).Errorf("RPC <-- ERROR: %s", err)
-			}
-			// If it doesn't have a method I don't know what to do now
-			if req == nil || req.Method == "" {
-				log.L(ctx).Error("RPC <-- ERROR: Unable to process received message")
-			}
-			if req.Method == "eth_subscription" {
-				subID := req.Params.Subscription.String()
-				rc.subMutex.Lock()
-				subChan, ok := rc.subscriptions[subID]
-				rc.subMutex.Unlock()
-				if ok {
-					subChan <- req
-				} else {
-					// No active sub found for this one. Dropping it
-					log.L(ctx).Warnf("RPC <-- WARN: Received subscription event for untracked subscription %s", subID)
-				}
-			}
-		}
-		rc.pendingSubMutex.Lock()
-		id := res.ID.AsString()
-		if subChan, ok := rc.pendingSubscriptions[id]; ok {
-			delete(rc.pendingSubscriptions, res.ID.String())
-			rc.pendingSubMutex.Unlock()
-			subID := res.Result.AsString()
-			rc.subMutex.Lock()
-			rc.subscriptions[subID] = subChan
-			rc.subMutex.Unlock()
+		rpcRes := RPCResponse{}
+		if err := json.Unmarshal(bytes, &rpcRes); err != nil {
+			log.L(ctx).Errorf("RPC <-- ERROR invalid data '%s': %s", bytes, err)
+		} else if rpcRes.Method == "eth_subscription" {
+			rc.handleSubscriptionNotification(ctx, &rpcRes)
 		} else {
-			rc.pendingSubMutex.Unlock()
+			// ID should match a request we sent
+			inflightSubscribe, inflightCall := rc.popInflight(rpcRes.ID.AsString())
+			switch {
+			case inflightSubscribe != nil:
+				rc.handleSubscriptionConfirm(ctx, &rpcRes, inflightSubscribe)
+			case inflightCall != nil:
+				inflightCall <- &rpcRes // assured not to block as we allocate one slot, and pop first time we see it
+			default:
+				log.L(ctx).Warnf("RPC[%s] <-- Received unexpected RPC response: %+v", rpcRes.ID.AsString(), rpcRes)
+			}
 		}
 	}
 }

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -1,0 +1,209 @@
+// Copyright © 2023 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcbackend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly-common/pkg/i18n"
+	"github.com/hyperledger/firefly-common/pkg/log"
+	"github.com/hyperledger/firefly-common/pkg/wsclient"
+	"github.com/hyperledger/firefly-signer/internal/signermsgs"
+	"github.com/sirupsen/logrus"
+)
+
+// WSBackend performs communication with a backend
+type WSBackend interface {
+	CallRPC(ctx context.Context, method string, params ...interface{}) (id string, rpcErr *RPCError)
+	Subscribe(ctx context.Context, subChannel chan *RPCSubscriptionRequest, params ...interface{}) (error *RPCError)
+	UnsubscribeAll(ctx context.Context) (error *RPCError)
+	Connect(ctx context.Context) error
+}
+
+// NewRPCClient Constructor
+func NewWSRPCClient(client wsclient.WSClient) WSBackend {
+	return NewWSRPCClientWithOption(client, RPCClientOptions{})
+}
+
+// NewRPCClientWithOption Constructor
+func NewWSRPCClientWithOption(client wsclient.WSClient, options RPCClientOptions) WSBackend {
+	wsRPCClient := &WSRPCClient{
+		client:               client,
+		subscriptions:        make(map[string]chan *RPCSubscriptionRequest),
+		pendingSubscriptions: make(map[string]chan *RPCSubscriptionRequest),
+	}
+
+	if options.MaxConcurrentRequest > 0 {
+		wsRPCClient.concurrencySlots = make(chan bool, options.MaxConcurrentRequest)
+	}
+
+	return wsRPCClient
+}
+
+type WSRPCClient struct {
+	client               wsclient.WSClient
+	concurrencySlots     chan bool
+	requestCounter       int64
+	subscriptions        map[string]chan *RPCSubscriptionRequest
+	pendingSubscriptions map[string]chan *RPCSubscriptionRequest
+	pendingSubMutex      sync.Mutex
+	subMutex             sync.Mutex
+}
+
+func (rc *WSRPCClient) Connect(ctx context.Context) error {
+	if err := rc.client.Connect(); err != nil {
+		return err
+	}
+	go rc.receiveLoop(ctx)
+	return nil
+}
+
+func (rc *WSRPCClient) allocateRequestID(req *RPCRequest) string {
+	reqID := fmt.Sprintf(`%.9d`, atomic.AddInt64(&rc.requestCounter, 1))
+	req.ID = fftypes.JSONAnyPtr(`"` + reqID + `"`)
+	return reqID
+}
+
+func (rc *WSRPCClient) Subscribe(ctx context.Context, subChannel chan *RPCSubscriptionRequest, params ...interface{}) (error *RPCError) {
+	rc.pendingSubMutex.Lock()
+	defer rc.pendingSubMutex.Unlock()
+	reqID, err := rc.CallRPC(ctx, "eth_subscribe", params...)
+	if err != nil {
+		return err
+	}
+	rc.pendingSubscriptions[reqID] = subChannel
+	return nil
+}
+
+func (rc *WSRPCClient) UnsubscribeAll(ctx context.Context) (error *RPCError) {
+	rc.subMutex.Lock()
+	for subID, subChan := range rc.subscriptions {
+		close(subChan)
+		delete(rc.subscriptions, subID)
+		_, err := rc.CallRPC(ctx, "eth_unsubscribe", subID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rc *WSRPCClient) CallRPC(ctx context.Context, method string, params ...interface{}) (id string, rpcErr *RPCError) {
+	req := &RPCRequest{
+		JSONRpc: "2.0",
+		Method:  method,
+		Params:  make([]*fftypes.JSONAny, len(params)),
+	}
+	for i, param := range params {
+		b, err := json.Marshal(param)
+		if err != nil {
+			return "", &RPCError{Code: int64(RPCCodeInvalidRequest), Message: i18n.NewError(ctx, signermsgs.MsgInvalidParam, i, method, err).Error()}
+		}
+		req.Params[i] = fftypes.JSONAnyPtrBytes(b)
+	}
+	reqID, err := rc.request(ctx, req)
+	if err != nil {
+		return reqID, &RPCError{Code: int64(RPCCodeInvalidRequest), Message: i18n.NewError(ctx, signermsgs.MsgInvalidParam, 0, method, err).Error()}
+	}
+	return reqID, nil
+}
+
+func (rc *WSRPCClient) request(ctx context.Context, rpcReq *RPCRequest) (id string, err error) {
+	if rc.concurrencySlots != nil {
+		select {
+		case rc.concurrencySlots <- true:
+			// wait for the concurrency slot and continue
+		case <-ctx.Done():
+			return "", i18n.NewError(ctx, signermsgs.MsgRequestCanceledContext, rpcReq.ID)
+		}
+		defer func() {
+			<-rc.concurrencySlots
+		}()
+	}
+
+	// We always set the back-end request ID - as we need to support requests coming in from
+	// multiple concurrent clients on our front-end that might use clashing IDs.
+	reqID := rc.allocateRequestID(rpcReq)
+	jsonInput, _ := json.Marshal(rpcReq)
+
+	log.L(ctx).Debugf("RPC[%s] --> %s", reqID, rpcReq.Method)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		log.L(ctx).Tracef("RPC[%s] INPUT: %s", reqID, jsonInput)
+	}
+	err = rc.client.Send(ctx, jsonInput)
+
+	// Restore the original ID
+	if err != nil {
+		err := i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, err)
+		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, err)
+		return reqID, err
+	}
+	return reqID, nil
+}
+
+func (rc *WSRPCClient) receiveLoop(ctx context.Context) {
+	for {
+		bytes, ok := <-rc.client.Receive()
+		if !ok {
+			return
+		}
+		res := &RPCResponse{}
+		if err := json.Unmarshal(bytes, res); err != nil {
+			log.L(ctx).Errorf("RPC <-- ERROR: %s", err)
+		}
+		// If it doesn't have a result, it might be a request instead
+		if res == nil || res.Result == nil || res.Result.String() == "" {
+			req := &RPCSubscriptionRequest{}
+			if err := json.Unmarshal(bytes, req); err != nil {
+				log.L(ctx).Errorf("RPC <-- ERROR: %s", err)
+			}
+			// If it doesn't have a method I don't know what to do now
+			if req == nil || req.Method == "" {
+				log.L(ctx).Error("RPC <-- ERROR: Unable to process received message")
+			}
+			if req.Method == "eth_subscription" {
+				subID := req.Params.Subscription.String()
+				rc.subMutex.Lock()
+				subChan, ok := rc.subscriptions[subID]
+				rc.subMutex.Unlock()
+				if ok {
+					subChan <- req
+				} else {
+					// No active sub found for this one. Dropping it
+					log.L(ctx).Warnf("RPC <-- WARN: Received subscription event for untracked subscription %s", subID)
+				}
+			}
+		}
+		rc.pendingSubMutex.Lock()
+		id := res.ID.AsString()
+		if subChan, ok := rc.pendingSubscriptions[id]; ok {
+			delete(rc.pendingSubscriptions, res.ID.String())
+			rc.pendingSubMutex.Unlock()
+			subID := res.Result.AsString()
+			rc.subMutex.Lock()
+			rc.subscriptions[subID] = subChan
+			rc.subMutex.Unlock()
+		} else {
+			rc.pendingSubMutex.Unlock()
+		}
+	}
+}

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -31,13 +31,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// RPCCallAndSubscribe performs communication over a websocket with a JSON/RPC endpoint
+// WebSocketRPCClient performs communication over a websocket with an Ethereum JSON/RPC endpoint
 //
 // - Manages websocket connect/reconnect with keepalive etc.
 // - Manages subscriptions with a local ID, so they re-established automatically after reconnect
 // - Allows synchronous exchange over the WebSocket so you don't have to maintain a separate HTTP connection too
-type RPCCallAndSubscribe interface {
-	RPCCaller
+type WebSocketRPCClient interface {
+	RPC
 	Subscribe(ctx context.Context, params ...interface{}) (sub Subscription, error *RPCError)
 	Subscriptions() []Subscription
 	UnsubscribeAll(ctx context.Context) (error *RPCError)
@@ -46,7 +46,7 @@ type RPCCallAndSubscribe interface {
 }
 
 // NewRPCClient Constructor
-func NewWSRPCClient(wsConf *wsclient.WSConfig) RPCCallAndSubscribe {
+func NewWSRPCClient(wsConf *wsclient.WSConfig) WebSocketRPCClient {
 	return &wsRPCClient{
 		wsConf:             *wsConf,
 		calls:              make(map[string]chan *RPCResponse),

--- a/pkg/rpcbackend/wsbackend_test.go
+++ b/pkg/rpcbackend/wsbackend_test.go
@@ -1,0 +1,97 @@
+// Copyright © 2023 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcbackend
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/firefly-common/pkg/wsclient"
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func generateConfig() *wsclient.WSConfig {
+	return &wsclient.WSConfig{}
+}
+
+func TestWSRPCConnect(t *testing.T) {
+	_, _, url, close := wsclient.NewTestWSServer(func(req *http.Request) {
+		assert.Equal(t, "/test", req.URL.Path)
+	})
+	defer close()
+
+	// Init clean config
+	wsConfig := generateConfig()
+
+	wsConfig.HTTPURL = url
+	wsConfig.WSKeyPath = "/test"
+	wsConfig.HeartbeatInterval = 50 * time.Millisecond
+	wsConfig.InitialConnectAttempts = 2
+
+	wsc, err := wsclient.New(context.Background(), wsConfig, nil, nil)
+	assert.NoError(t, err)
+
+	wsRPCClient := NewWSRPCClient(wsc)
+
+	err = wsRPCClient.Connect(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestWSRPCSubscribe(t *testing.T) {
+	toServer, fromServer, url, close := wsclient.NewTestWSServer(func(req *http.Request) {
+		assert.Equal(t, "/test", req.URL.Path)
+	})
+	defer close()
+
+	// Init clean config
+	wsConfig := generateConfig()
+
+	wsConfig.HTTPURL = url
+	wsConfig.WSKeyPath = "/test"
+	wsConfig.HeartbeatInterval = 50 * time.Millisecond
+	wsConfig.InitialConnectAttempts = 2
+
+	wsc, err := wsclient.New(context.Background(), wsConfig, nil, nil)
+	assert.NoError(t, err)
+
+	wsRPCClient := NewWSRPCClient(wsc)
+
+	err = wsRPCClient.Connect(context.Background())
+	assert.NoError(t, err)
+
+	subChan := make(chan *RPCSubscriptionRequest)
+	wsRPCClient.Subscribe(context.Background(), subChan, "newHeads")
+
+	msg := <-toServer
+	assert.Equal(t, "{\"jsonrpc\":\"2.0\",\"id\":\"000000001\",\"method\":\"eth_subscribe\",\"params\":[\"newHeads\"]}", msg)
+
+	fromServer <- `{"jsonrpc":"2.0","id":"000000001","result":"0x9ce59a13059e417087c02d3236a0b1cc"}`
+	fromServer <- `{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":{"extraData":"0xd983010305844765746887676f312e342e328777696e646f7773","gasLimit":"0x47e7c4","gasUsed":"0x38658","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","nonce":"0x084149998194cc5f","number":"0x1348c9","parentHash":"0x7736fab79e05dc611604d22470dadad26f56fe494421b5b333de816ce1f25701","receiptRoot":"0x2fab35823ad00c7bb388595cb46652fe7886e00660a01e867824d3dceb1c8d36","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","stateRoot":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378","timestamp":"0x56ffeff8","transactionsRoot":"0x0167ffa60e3ebc0b080cdb95f7c0087dd6c0e61413140e39d94d3468d7c9689f","hash":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378"},"subscription":"0x9ce59a13059e417087c02d3236a0b1cc"}}`
+
+	newHead := <-subChan
+	assert.NotNil(t, newHead)
+
+	blockNumber := ethtypes.NewHexInteger(newHead.Params.Result.JSONObject().GetInteger("number"))
+	assert.Equal(t, big.NewInt(1263817), blockNumber.BigInt())
+
+	hash := newHead.Params.Result.JSONObject().GetString("hash")
+	assert.Equal(t, "0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378", hash)
+}

--- a/pkg/rpcbackend/wsbackend_test.go
+++ b/pkg/rpcbackend/wsbackend_test.go
@@ -55,6 +55,19 @@ func TestWSRPCConnect(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWSRPCConnectError(t *testing.T) {
+	// Init clean config
+	wsConfig := generateConfig()
+
+	wsc, err := wsclient.New(context.Background(), wsConfig, nil, nil)
+	assert.NoError(t, err)
+
+	wsRPCClient := NewWSRPCClient(wsc)
+
+	err = wsRPCClient.Connect(context.Background())
+	assert.Regexp(t, "FF00148", err)
+}
+
 func TestWSRPCSubscribe(t *testing.T) {
 	toServer, fromServer, url, close := wsclient.NewTestWSServer(func(req *http.Request) {
 		assert.Equal(t, "/test", req.URL.Path)
@@ -83,6 +96,15 @@ func TestWSRPCSubscribe(t *testing.T) {
 	msg := <-toServer
 	assert.Equal(t, "{\"jsonrpc\":\"2.0\",\"id\":\"000000001\",\"method\":\"eth_subscribe\",\"params\":[\"newHeads\"]}", msg)
 
+	// Test error cases first to make sure client ignores stuff it doesn't care about
+	// should log: WARN: Received subscription event for untracked subscription
+	fromServer <- `{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":{"extraData":"0xd983010305844765746887676f312e342e328777696e646f7773","gasLimit":"0x47e7c4","gasUsed":"0x38658","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","nonce":"0x084149998194cc5f","number":"0x1348c9","parentHash":"0x7736fab79e05dc611604d22470dadad26f56fe494421b5b333de816ce1f25701","receiptRoot":"0x2fab35823ad00c7bb388595cb46652fe7886e00660a01e867824d3dceb1c8d36","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","stateRoot":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378","timestamp":"0x56ffeff8","transactionsRoot":"0x0167ffa60e3ebc0b080cdb95f7c0087dd6c0e61413140e39d94d3468d7c9689f","hash":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378"},"subscription":"0x99999999999999999999999999999999"}}`
+	// should log: ERROR: Unable to process received message
+	fromServer <- `{"nonsense": true}`
+	// should log a deserialization error
+	fromServer <- `notjson`
+
+	// Then test real subscription message
 	fromServer <- `{"jsonrpc":"2.0","id":"000000001","result":"0x9ce59a13059e417087c02d3236a0b1cc"}`
 	fromServer <- `{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":{"extraData":"0xd983010305844765746887676f312e342e328777696e646f7773","gasLimit":"0x47e7c4","gasUsed":"0x38658","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","nonce":"0x084149998194cc5f","number":"0x1348c9","parentHash":"0x7736fab79e05dc611604d22470dadad26f56fe494421b5b333de816ce1f25701","receiptRoot":"0x2fab35823ad00c7bb388595cb46652fe7886e00660a01e867824d3dceb1c8d36","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","stateRoot":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378","timestamp":"0x56ffeff8","transactionsRoot":"0x0167ffa60e3ebc0b080cdb95f7c0087dd6c0e61413140e39d94d3468d7c9689f","hash":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378"},"subscription":"0x9ce59a13059e417087c02d3236a0b1cc"}}`
 
@@ -94,4 +116,118 @@ func TestWSRPCSubscribe(t *testing.T) {
 
 	hash := newHead.Params.Result.JSONObject().GetString("hash")
 	assert.Equal(t, "0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378", hash)
+
+	wsRPCClient.UnsubscribeAll(context.Background())
+
+	res, ok := <-subChan
+	assert.Nil(t, res)
+	assert.False(t, ok)
+
+	wsRPCClient.Close()
+}
+
+func TestWSRPCSubscribeError(t *testing.T) {
+	_, _, url, close := wsclient.NewTestWSServer(func(req *http.Request) {
+		assert.Equal(t, "/test", req.URL.Path)
+	})
+	defer close()
+
+	// Init clean config
+	wsConfig := generateConfig()
+
+	wsConfig.HTTPURL = url
+	wsConfig.WSKeyPath = "/test"
+	wsConfig.HeartbeatInterval = 50 * time.Millisecond
+	wsConfig.InitialConnectAttempts = 2
+
+	wsc, err := wsclient.New(context.Background(), wsConfig, nil, nil)
+	assert.NoError(t, err)
+
+	wsRPCClient := NewWSRPCClient(wsc)
+
+	err = wsRPCClient.Connect(context.Background())
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	subChan := make(chan *RPCSubscriptionRequest)
+	wsRPCClient.Subscribe(ctx, subChan, []bool{false})
+}
+
+func TestWSRPCCallRPCError(t *testing.T) {
+	_, _, url, close := wsclient.NewTestWSServer(func(req *http.Request) {
+		assert.Equal(t, "/test", req.URL.Path)
+	})
+	defer close()
+
+	// Init clean config
+	wsConfig := generateConfig()
+
+	wsConfig.HTTPURL = url
+	wsConfig.WSKeyPath = "/test"
+	wsConfig.HeartbeatInterval = 50 * time.Millisecond
+	wsConfig.InitialConnectAttempts = 2
+
+	wsc, err := wsclient.New(context.Background(), wsConfig, nil, nil)
+	assert.NoError(t, err)
+
+	wsRPCClient := NewWSRPCClient(wsc)
+
+	err = wsRPCClient.Connect(context.Background())
+	assert.NoError(t, err)
+
+	bad := map[bool]bool{false: true}
+	_, rpcErr := wsRPCClient.CallRPC(context.Background(), "eth_call", bad)
+	assert.Error(t, rpcErr.Error())
+}
+
+func TestWSRPCUnsubscribeError(t *testing.T) {
+	toServer, fromServer, url, close := wsclient.NewTestWSServer(func(req *http.Request) {
+		assert.Equal(t, "/test", req.URL.Path)
+	})
+	defer close()
+
+	// Init clean config
+	wsConfig := generateConfig()
+
+	wsConfig.HTTPURL = url
+	wsConfig.WSKeyPath = "/test"
+	wsConfig.HeartbeatInterval = 50 * time.Millisecond
+	wsConfig.InitialConnectAttempts = 2
+
+	wsc, err := wsclient.New(context.Background(), wsConfig, nil, nil)
+	assert.NoError(t, err)
+
+	wsRPCClient := NewWSRPCClient(wsc)
+
+	err = wsRPCClient.Connect(context.Background())
+	assert.NoError(t, err)
+
+	subChan := make(chan *RPCSubscriptionRequest)
+	wsRPCClient.Subscribe(context.Background(), subChan, "newHeads")
+
+	msg := <-toServer
+	assert.Equal(t, "{\"jsonrpc\":\"2.0\",\"id\":\"000000001\",\"method\":\"eth_subscribe\",\"params\":[\"newHeads\"]}", msg)
+	fromServer <- `{"jsonrpc":"2.0","id":"000000001","result":"0x9ce59a13059e417087c02d3236a0b1cc"}`
+	fromServer <- `{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":{"extraData":"0xd983010305844765746887676f312e342e328777696e646f7773","gasLimit":"0x47e7c4","gasUsed":"0x38658","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","nonce":"0x084149998194cc5f","number":"0x1348c9","parentHash":"0x7736fab79e05dc611604d22470dadad26f56fe494421b5b333de816ce1f25701","receiptRoot":"0x2fab35823ad00c7bb388595cb46652fe7886e00660a01e867824d3dceb1c8d36","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","stateRoot":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378","timestamp":"0x56ffeff8","transactionsRoot":"0x0167ffa60e3ebc0b080cdb95f7c0087dd6c0e61413140e39d94d3468d7c9689f","hash":"0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378"},"subscription":"0x9ce59a13059e417087c02d3236a0b1cc"}}`
+
+	newHead := <-subChan
+	assert.NotNil(t, newHead)
+
+	blockNumber := ethtypes.NewHexInteger(newHead.Params.Result.JSONObject().GetInteger("number"))
+	assert.Equal(t, big.NewInt(1263817), blockNumber.BigInt())
+
+	hash := newHead.Params.Result.JSONObject().GetString("hash")
+	assert.Equal(t, "0xb3346685172db67de536d8765c43c31009d0eb3bd9c501c9be3229203f15f378", hash)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	wsRPCClient.UnsubscribeAll(ctx)
+
+	res, ok := <-subChan
+	assert.Nil(t, res)
+	assert.False(t, ok)
+
+	wsRPCClient.Close()
 }


### PR DESCRIPTION
This PR adds a JSONRPC WebSocket client.

- Provides sync `CallRPC` functionality over an async WebSocket transport
    - Manages JSON/RPC request IDs for you
    - Provides automatic reconnect, and all the other quality of life benefits of the `firefly-common` WebSocket impl
- Supports `eth_subscribe`/`eth_unsubscribe` with a higher level `Subscription` semantic
    - Automatically resubscribes if your WebSocket reconnects
    - Has a client-side ID to track your subscription, as well as the server-side ID (which changes on reconnect)
    - At-most-once delivery semantics is all you get with raw Ethereum WebSockets (it's all the `eth_` protocol supports) - you miss it, you lose it
        - If you need more than that, use the full [FireFly core](https://github.com/kaleido-io/firefly) which provides reliable check-pointed subscriptions with a higher level blockchain connector
