### PR TITLE
Fix auto reconnect for RPC WebSocket

### DIFF
--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -457,7 +457,9 @@ func (rc *wsRPCClient) handleSubscriptionConfirm(ctx context.Context, inflightSu
 	log.L(ctx).Infof("Subscribed %s with server subscription ID '%s'", inflightSub.localID, subscriptionID)
 	rc.addActiveSub(inflightSub, subscriptionID)
 	// all was good, if someone is waiting to be told, notify them
-	resChl <- nil
+	if resChl != nil {
+		resChl <- nil
+	}
 }
 
 func (rc *wsRPCClient) deliverCallResponse(ctx context.Context, inflightCall chan *RPCResponse, rpcRes *RPCResponse) {

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -220,7 +220,7 @@ func (rc *wsRPCClient) addConfiguredSub(ctx context.Context, params []interface{
 		rc:             rc,
 		localID:        fftypes.NewUUID(),
 		params:         params,
-		newSubResponse: make(chan *RPCError),
+		newSubResponse: make(chan *RPCError, 1),
 		notifications:  make(chan *RPCSubscriptionNotification), // blocking channel for these, but Unsubscribe will unblock by cancelling ctx
 	}
 	s.ctx, s.cancelCtx = context.WithCancel(ctx)


### PR DESCRIPTION
In the case of a reconnect the `resChl` was `nil` so sending `nil` to it ended up blocking, causing the receiver to not receive any further messages.