### PR TITLE
Update receipts and TX info

### DIFF
--- a/pkg/ethereum/ethereum.go
+++ b/pkg/ethereum/ethereum.go
@@ -27,7 +27,7 @@ import (
 type TXReceiptJSONRPC struct {
 	BlockHash         ethtypes.HexBytes0xPrefix     `json:"blockHash"`
 	BlockNumber       *ethtypes.HexInteger          `json:"blockNumber"`
-	ContractAddress   *ethtypes.AddressWithChecksum `json:"contractAddress"`
+	ContractAddress   *ethtypes.Address0xHex        `json:"contractAddress"`
 	CumulativeGasUsed *ethtypes.HexInteger          `json:"cumulativeGasUsed"`
 	From              *ethtypes.AddressWithChecksum `json:"from"`
 	GasUsed           *ethtypes.HexInteger          `json:"gasUsed"`
@@ -54,22 +54,22 @@ type ReceiptExtraInfo struct {
 
 // txInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data
 type TXInfoJSONRPC struct {
-	BlockHash        ethtypes.HexBytes0xPrefix     `json:"blockHash"`   // null if pending
-	BlockNumber      *ethtypes.HexInteger          `json:"blockNumber"` // null if pending
-	From             *ethtypes.AddressWithChecksum `json:"from"`
-	ChainID          *ethtypes.HexInteger          `json:"chainID"`
-	Gas              *ethtypes.HexInteger          `json:"gas"`
-	GasPrice         *ethtypes.HexInteger          `json:"gasPrice"`
-	Hash             ethtypes.HexBytes0xPrefix     `json:"hash"`
-	Input            ethtypes.HexBytes0xPrefix     `json:"input"`
-	Nonce            *ethtypes.HexInteger          `json:"nonce"`
-	R                *ethtypes.HexInteger          `json:"r"`
-	S                *ethtypes.HexInteger          `json:"s"`
-	To               *ethtypes.AddressWithChecksum `json:"to"`
-	TransactionIndex *ethtypes.HexInteger          `json:"transactionIndex"` // null if pending
-	Type             *ethtypes.HexInteger          `json:"type"`
-	V                *ethtypes.HexInteger          `json:"v"`
-	Value            *ethtypes.HexInteger          `json:"value"`
+	BlockHash        ethtypes.HexBytes0xPrefix `json:"blockHash"`   // null if pending
+	BlockNumber      *ethtypes.HexInteger      `json:"blockNumber"` // null if pending
+	From             *ethtypes.Address0xHex    `json:"from"`
+	ChainID          *ethtypes.HexInteger      `json:"chainID"`
+	Gas              *ethtypes.HexInteger      `json:"gas"`
+	GasPrice         *ethtypes.HexInteger      `json:"gasPrice"`
+	Hash             ethtypes.HexBytes0xPrefix `json:"hash"`
+	Input            ethtypes.HexBytes0xPrefix `json:"input"`
+	Nonce            *ethtypes.HexInteger      `json:"nonce"`
+	R                *ethtypes.HexInteger      `json:"r"`
+	S                *ethtypes.HexInteger      `json:"s"`
+	To               *ethtypes.Address0xHex    `json:"to"`
+	TransactionIndex *ethtypes.HexInteger      `json:"transactionIndex"` // null if pending
+	Type             *ethtypes.HexInteger      `json:"type"`
+	V                *ethtypes.HexInteger      `json:"v"`
+	Value            *ethtypes.HexInteger      `json:"value"`
 }
 
 func (t *TXInfoJSONRPC) Cost() *big.Int {

--- a/pkg/ethereum/ethereum.go
+++ b/pkg/ethereum/ethereum.go
@@ -25,17 +25,17 @@ import (
 
 // txReceiptJSONRPC is the receipt obtained over JSON/RPC from the ethereum client, with gas used, logs and contract address
 type TXReceiptJSONRPC struct {
-	BlockHash         ethtypes.HexBytes0xPrefix     `json:"blockHash"`
-	BlockNumber       *ethtypes.HexInteger          `json:"blockNumber"`
-	ContractAddress   *ethtypes.Address0xHex        `json:"contractAddress"`
-	CumulativeGasUsed *ethtypes.HexInteger          `json:"cumulativeGasUsed"`
-	From              *ethtypes.AddressWithChecksum `json:"from"`
-	GasUsed           *ethtypes.HexInteger          `json:"gasUsed"`
-	Logs              []*LogJSONRPC                 `json:"logs"`
-	Status            *ethtypes.HexInteger          `json:"status"`
-	To                *ethtypes.AddressWithChecksum `json:"to"`
-	TransactionHash   ethtypes.HexBytes0xPrefix     `json:"transactionHash"`
-	TransactionIndex  *ethtypes.HexInteger          `json:"transactionIndex"`
+	BlockHash         ethtypes.HexBytes0xPrefix `json:"blockHash"`
+	BlockNumber       *ethtypes.HexInteger      `json:"blockNumber"`
+	ContractAddress   *ethtypes.Address0xHex    `json:"contractAddress"`
+	CumulativeGasUsed *ethtypes.HexInteger      `json:"cumulativeGasUsed"`
+	From              *ethtypes.Address0xHex    `json:"from"`
+	GasUsed           *ethtypes.HexInteger      `json:"gasUsed"`
+	Logs              []*LogJSONRPC             `json:"logs"`
+	Status            *ethtypes.HexInteger      `json:"status"`
+	To                *ethtypes.Address0xHex    `json:"to"`
+	TransactionHash   ethtypes.HexBytes0xPrefix `json:"transactionHash"`
+	TransactionIndex  *ethtypes.HexInteger      `json:"transactionIndex"`
 }
 
 // receiptExtraInfo is the version of the receipt we store under the TX.
@@ -43,13 +43,13 @@ type TXReceiptJSONRPC struct {
 // - We omit fields already in the standardized cross-blockchain section
 // - We format numbers as decimals
 type ReceiptExtraInfo struct {
-	ContractAddress   *ethtypes.AddressWithChecksum `json:"contractAddress"`
-	CumulativeGasUsed *fftypes.FFBigInt             `json:"cumulativeGasUsed"`
-	From              *ethtypes.AddressWithChecksum `json:"from"`
-	To                *ethtypes.AddressWithChecksum `json:"to"`
-	GasUsed           *fftypes.FFBigInt             `json:"gasUsed"`
-	Status            *fftypes.FFBigInt             `json:"status"`
-	ErrorMessage      *string                       `json:"errorMessage"`
+	ContractAddress   *ethtypes.Address0xHex `json:"contractAddress"`
+	CumulativeGasUsed *fftypes.FFBigInt      `json:"cumulativeGasUsed"`
+	From              *ethtypes.Address0xHex `json:"from"`
+	To                *ethtypes.Address0xHex `json:"to"`
+	GasUsed           *fftypes.FFBigInt      `json:"gasUsed"`
+	Status            *fftypes.FFBigInt      `json:"status"`
+	ErrorMessage      *string                `json:"errorMessage"`
 }
 
 // txInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data


### PR DESCRIPTION
Having a mix of capitalization was causing some issues in a variety of ways. This change normalizes to lowercase, and then leaves it up to the calling code if it wants to display and address with a checksum or not.