### PR TITLE
fix: when decoding addresses restrict to 20 bytes

### DIFF
--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -128,6 +128,16 @@ func decodeABIUnsignedInt(ctx context.Context, desc string, block []byte, _, hea
 		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
 	}
 	cv.Value = new(big.Int).SetBytes(block[headPosition : headPosition+32])
+	return cv, err
+}
+
+func decodeABIAddress(ctx context.Context, desc string, block []byte, _, headPosition int, component *typeComponent) (cv *ComponentValue, err error) {
+	// Addresses are 20 bytes, but are represented as a 32 bit unsigned integer so we remove the proceeding 12 bytes and then read the rest as the address
+	cv = &ComponentValue{Component: component}
+	if headPosition+32 > len(block) {
+		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
+	}
+	cv.Value = new(big.Int).SetBytes(block[headPosition+12 : headPosition+32])
 	return cv, err
 }
 

--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -127,17 +127,9 @@ func decodeABIUnsignedInt(ctx context.Context, desc string, block []byte, _, hea
 	if headPosition+32 > len(block) {
 		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
 	}
-	cv.Value = new(big.Int).SetBytes(block[headPosition : headPosition+32])
-	return cv, err
-}
 
-func decodeABIAddress(ctx context.Context, desc string, block []byte, _, headPosition int, component *typeComponent) (cv *ComponentValue, err error) {
-	// Addresses are 20 bytes, but are represented as a 32 bit unsigned integer so we remove the proceeding 12 bytes and then read the rest as the address
-	cv = &ComponentValue{Component: component}
-	if headPosition+32 > len(block) {
-		return nil, i18n.NewError(ctx, signermsgs.MsgNotEnoughBytesABIValue, component, desc)
-	}
-	cv.Value = new(big.Int).SetBytes(block[headPosition+12 : headPosition+32])
+	// When we're reading bytes, need to make sure we're reading the correct size number of bytes for the uint size
+	cv.Value = new(big.Int).SetBytes(block[headPosition+(32-(int(component.m/8))) : headPosition+32])
 	return cv, err
 }
 

--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -1035,12 +1035,18 @@ func TestDecodeAddressWithNonZeroPadding(t *testing.T) {
 		Inputs: ParameterArray{
 			{Type: "address"},
 			{Type: "uint256"},
+			{Type: "uint160"},
+			{Type: "uint64"},
+			{Type: "uint8"},
 		},
 	}
 
-	d, err := hex.DecodeString("095ea7b3" +
-		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // Valid address padded with non-zero bytes
-		"0000000000000000000000000000000000000000000000000000000000000064")  // 100
+	d, err := hex.DecodeString("9028b841" +
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // (address) 0xab0974bbed8afc5212e951c8498873319d02d025
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // (uint256) 0xffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // (uint160) 0xab0974bbed8afc5212e951c8498873319d02d025
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // ( uint64) 0x498873319d02d025
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025")  // (  uint8) 0x25  
 	assert.NoError(t, err)
 
 	cv, err := f.DecodeCallData(d)
@@ -1048,5 +1054,16 @@ func TestDecodeAddressWithNonZeroPadding(t *testing.T) {
 
 	address, _ := cv.Children[0].JSON()
 	assert.Equal(t, "\"ab0974bbed8afc5212e951c8498873319d02d025\"", string(address))
-	assert.Equal(t, "100", cv.Children[1].Value.(*big.Int).String())
+
+	value, _ := cv.Children[1].JSON()
+	assert.Equal(t, "\"115792089237316195423570985008202854513430464469730409417913252338120266010661\"", string(value))
+
+	value, _ = cv.Children[2].JSON()
+	assert.Equal(t, "\"976448297491382722293530211171951349863068913701\"", string(value))
+
+	value, _ = cv.Children[3].JSON()
+	assert.Equal(t, "\"5298611618526187557\"", string(value))
+
+	value, _ = cv.Children[4].JSON()
+	assert.Equal(t, "\"37\"", string(value))
 }

--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -1026,4 +1026,27 @@ func TestDecodeABIElementInsufficientDataTuple(t *testing.T) {
 
 	_, _, err = decodeABIElement(context.Background(), "", block, 0, 0, tc.(*typeComponent).tupleChildren[0])
 	assert.Regexp(t, "FF22045", err)
+}
+
+func TestDecodeAddressWithNonZeroPadding(t *testing.T) {
+
+	f := &Entry{
+		Name: "approve",
+		Inputs: ParameterArray{
+			{Type: "address"},
+			{Type: "uint256"},
+		},
+	}
+
+	d, err := hex.DecodeString("095ea7b3" +
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // Valid address padded with non-zero bytes
+		"0000000000000000000000000000000000000000000000000000000000000064")  // 100
+	assert.NoError(t, err)
+
+	cv, err := f.DecodeCallData(d)
+	assert.NoError(t, err)
+
+	address, _ := cv.Children[0].JSON()
+	assert.Equal(t, "\"ab0974bbed8afc5212e951c8498873319d02d025\"", string(address))
+	assert.Equal(t, "100", cv.Children[1].Value.(*big.Int).String())
 }

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -227,7 +227,7 @@ var (
 		},
 		jsonEncodingType: JSONEncodingTypeBytes,
 		encodeABIData:    encodeABIUnsignedInteger,
-		decodeABIData:    decodeABIUnsignedInt,
+		decodeABIData:    decodeABIAddress,
 	})
 	ElementaryTypeBool = registerElementaryType(elementaryTypeInfo{
 		name:       BaseTypeBool,

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -227,7 +227,7 @@ var (
 		},
 		jsonEncodingType: JSONEncodingTypeBytes,
 		encodeABIData:    encodeABIUnsignedInteger,
-		decodeABIData:    decodeABIAddress,
+		decodeABIData:    decodeABIUnsignedInt,
 	})
 	ElementaryTypeBool = registerElementaryType(elementaryTypeInfo{
 		name:       BaseTypeBool,


### PR DESCRIPTION
ref: https://discordapp.com/channels/905194001349627914/928377875827154984/1194272891957694614

When indexing the BSC chain, it's been reported that the EVM connector crashes when indexing [this transaction](https://bscscan.com/tx/0x26a81f0d1aa4149627ca98ab8ac457b18ffe47f1d332676cf0747c6c36194ade). This is because the padding scheme used in the transaction is not using zero-bytes to pad out the value. When we parse the entire 32 bytes from the chunk into an integer, the padding non-zero bytes are contributing to the integer value, causing the parsed address value to overflow what can be actually been shown in 20 bytes. This issue is causing golang to panic and the EVM connector to crash.

The proposed fix is to decode addresses only on the right-most 20 bytes, and ignore the front 12 bytes from the chunk.