### PR TITLE
Expose API to directly call HashStruct from EIP-712 and M+N dims

### DIFF
--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -611,6 +611,7 @@ func TestDecodeABISignedIntOk(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, ElementaryTypeInt, cv.Children[0].Component.ElementaryType())
+	assert.Equal(t, uint16(256), cv.Children[0].Component.ElementaryM())
 	assert.Equal(t, int64(-0x12345), cv.Children[0].Value.(*big.Int).Int64())
 
 }
@@ -667,6 +668,8 @@ func TestDecodeABIFixedOk(t *testing.T) {
 	cv, err := p.DecodeABIData(d, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, ElementaryTypeFixed, cv.Children[0].Component.ElementaryType())
+	assert.Equal(t, uint16(64), cv.Children[0].Component.ElementaryM())
+	assert.Equal(t, uint16(4), cv.Children[0].Component.ElementaryN())
 	assert.Equal(t, "-7.4565", cv.Children[0].Value.(*big.Float).String())
 
 }
@@ -1046,7 +1049,7 @@ func TestDecodeAddressWithNonZeroPadding(t *testing.T) {
 		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // (uint256) 0xffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025
 		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // (uint160) 0xab0974bbed8afc5212e951c8498873319d02d025
 		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025" + // ( uint64) 0x498873319d02d025
-		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025")  // (  uint8) 0x25  
+		"ffffffffffffffffffffffffab0974bbed8afc5212e951c8498873319d02d025") // (  uint8) 0x25
 	assert.NoError(t, err)
 
 	cv, err := f.DecodeCallData(d)

--- a/pkg/abi/inputparsing.go
+++ b/pkg/abi/inputparsing.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -460,7 +460,7 @@ func walkTupleInput(ctx context.Context, breadcrumbs string, input interface{}, 
 	}
 	cv = &ComponentValue{
 		Component: component,
-		Children:  make([]*ComponentValue, len(iMap)),
+		Children:  make([]*ComponentValue, len(component.tupleChildren)),
 	}
 	for i, tupleChild := range component.tupleChildren {
 		if tupleChild.keyName == "" {

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -47,6 +47,8 @@ type TypeComponent interface {
 	String() string                     // gives the signature for this type level of the type component hierarchy
 	ComponentType() ComponentType       // classification of the component type (tuple, array or elemental)
 	ElementaryType() ElementaryTypeInfo // only non-nil for elementary components
+	ElementaryM() uint16                // only for N dimensioned elementary types
+	ElementaryN() uint16                // only for M dimensioned elementary types
 	ElementarySuffix() string           // only on elementary types with a suffix - expands "aliases" (so "uint" would have "256")
 	ElementaryFixed() bool              // whether the elementary type if fixed
 	ArrayChild() TypeComponent          // only non-nil for array components
@@ -378,6 +380,16 @@ func (tc *typeComponent) ElementaryFixed() bool {
 		return !tc.elementaryType.dynamic(tc)
 	}
 	return false
+}
+
+// M dimension of elementary type (if applicable)
+func (tc *typeComponent) ElementaryM() uint16 {
+	return tc.m
+}
+
+// N dimension of elementary type (if applicable)
+func (tc *typeComponent) ElementaryN() uint16 {
+	return tc.n
 }
 
 func (tc *typeComponent) KeyName() string {

--- a/pkg/eip712/typed_data_v4.go
+++ b/pkg/eip712/typed_data_v4.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -221,6 +221,11 @@ func encodeData(ctx context.Context, typeName string, v interface{}, allTypes Ty
 	encoded = buf.Bytes()
 	log.L(ctx).Tracef("encodeData(%s, %T): %s", typeName, v, encoded)
 	return encoded, nil
+}
+
+// HashStruct allows hashing of an individual structure, without the EIP-712 domain
+func HashStruct(ctx context.Context, typeName string, v interface{}, allTypes TypeSet) (result ethtypes.HexBytes0xPrefix, err error) {
+	return hashStruct(ctx, typeName, v, allTypes, "")
 }
 
 func hashStruct(ctx context.Context, typeName string, v interface{}, allTypes TypeSet, breadcrumbs string) (result ethtypes.HexBytes0xPrefix, err error) {

--- a/pkg/eip712/typed_data_v4_test.go
+++ b/pkg/eip712/typed_data_v4_test.go
@@ -82,6 +82,10 @@ func TestMessage_ExampleFromEIP712Spec(t *testing.T) {
 	ed, err := EncodeTypedDataV4(ctx, &p)
 	assert.NoError(t, err)
 	assert.Equal(t, "0xde26f53b35dd5ffdc13f8297e5cc7bbcb1a04bf33803bd2bf4a45eb251360cb8", ed.String())
+
+	hs, err := HashStruct(ctx, p.PrimaryType, p.Message, p.Types)
+	assert.NoError(t, err)
+	assert.Equal(t, "0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e", hs.String())
 }
 
 func TestMessage_EmptyMessage(t *testing.T) {

--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -211,7 +211,10 @@ func (t *Transaction) SignEIP1559(signer secp256k1.Signer, chainID int64) ([]byt
 	if err != nil {
 		return nil, err
 	}
+	return t.FinalizeEIP1559WithSignature(signaturePayload, sig)
+}
 
+func (t *Transaction) FinalizeEIP1559WithSignature(signaturePayload *TransactionSignaturePayload, sig *secp256k1.SignatureData) ([]byte, error) {
 	// Use the direct 0/1 Y-parity value
 	sig.UpdateEIP2930()
 

--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -145,13 +145,16 @@ func (t *Transaction) SignLegacyOriginal(signer secp256k1.Signer) ([]byte, error
 	if signer == nil {
 		return nil, i18n.NewError(context.Background(), signermsgs.MsgInvalidSigner)
 	}
-	signatureData := t.SignaturePayloadLegacyOriginal()
-	sig, err := signer.Sign(signatureData.data)
+	signaturePayload := t.SignaturePayloadLegacyOriginal()
+	sig, err := signer.Sign(signaturePayload.data)
 	if err != nil {
 		return nil, err
 	}
+	return t.FinalizeLegacyOriginalWithSignature(signaturePayload, sig)
+}
 
-	rlpList := t.addSignature(signatureData.rlpList, sig)
+func (t *Transaction) FinalizeLegacyOriginalWithSignature(signaturePayload *TransactionSignaturePayload, sig *secp256k1.SignatureData) ([]byte, error) {
+	rlpList := t.addSignature(signaturePayload.rlpList, sig)
 	return rlpList.Encode(), nil
 }
 
@@ -179,7 +182,10 @@ func (t *Transaction) SignLegacyEIP155(signer secp256k1.Signer, chainID int64) (
 	if err != nil {
 		return nil, err
 	}
+	return t.FinalizeLegacyEIP155WithSignature(signaturePayload, sig, chainID)
+}
 
+func (t *Transaction) FinalizeLegacyEIP155WithSignature(signaturePayload *TransactionSignaturePayload, sig *secp256k1.SignatureData, chainID int64) ([]byte, error) {
 	// Use the EIP-155 V value, of (2*ChainID + 35 + Y-parity)
 	sig.UpdateEIP155(chainID)
 

--- a/pkg/ethtypes/hexbytes.go
+++ b/pkg/ethtypes/hexbytes.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -17,6 +17,7 @@
 package ethtypes
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -28,6 +29,10 @@ type HexBytesPlain []byte
 
 // HexBytes0xPrefix are serialized to JSON as hex with an `0x` prefix
 type HexBytes0xPrefix []byte
+
+func (h HexBytesPlain) Equal(h2 HexBytesPlain) bool {
+	return bytes.Equal(h, h2)
+}
 
 func (h *HexBytesPlain) UnmarshalJSON(b []byte) error {
 	var s string
@@ -52,6 +57,10 @@ func (h HexBytesPlain) MarshalJSON() ([]byte, error) {
 
 func (h *HexBytes0xPrefix) UnmarshalJSON(b []byte) error {
 	return ((*HexBytesPlain)(h)).UnmarshalJSON(b)
+}
+
+func (h HexBytes0xPrefix) Equal(h2 HexBytes0xPrefix) bool {
+	return bytes.Equal(h, h2)
 }
 
 func (h HexBytes0xPrefix) String() string {

--- a/pkg/ethtypes/hexbytes.go
+++ b/pkg/ethtypes/hexbytes.go
@@ -30,7 +30,7 @@ type HexBytesPlain []byte
 // HexBytes0xPrefix are serialized to JSON as hex with an `0x` prefix
 type HexBytes0xPrefix []byte
 
-func (h HexBytesPlain) Equal(h2 HexBytesPlain) bool {
+func (h HexBytesPlain) Equals(h2 HexBytesPlain) bool {
 	return bytes.Equal(h, h2)
 }
 
@@ -59,7 +59,7 @@ func (h *HexBytes0xPrefix) UnmarshalJSON(b []byte) error {
 	return ((*HexBytesPlain)(h)).UnmarshalJSON(b)
 }
 
-func (h HexBytes0xPrefix) Equal(h2 HexBytes0xPrefix) bool {
+func (h HexBytes0xPrefix) Equals(h2 HexBytes0xPrefix) bool {
 	return bytes.Equal(h, h2)
 }
 

--- a/pkg/ethtypes/hexbytes_test.go
+++ b/pkg/ethtypes/hexbytes_test.go
@@ -90,3 +90,15 @@ func TestHexByteConstructors(t *testing.T) {
 		MustNewHexBytes0xPrefix("!wrong")
 	})
 }
+
+func TestHexByteEqual(t *testing.T) {
+	assert.True(t, HexBytesPlain(nil).Equal(nil))
+	assert.False(t, HexBytesPlain(nil).Equal(HexBytesPlain{0x00}))
+	assert.False(t, (HexBytesPlain{0x00}).Equal(nil))
+	assert.True(t, (HexBytesPlain{0x00}).Equal(HexBytesPlain{0x00}))
+
+	assert.True(t, HexBytes0xPrefix(nil).Equal(nil))
+	assert.False(t, HexBytes0xPrefix(nil).Equal(HexBytes0xPrefix{0x00}))
+	assert.False(t, (HexBytes0xPrefix{0x00}).Equal(nil))
+	assert.True(t, (HexBytes0xPrefix{0x00}).Equal(HexBytes0xPrefix{0x00}))
+}

--- a/pkg/ethtypes/hexbytes_test.go
+++ b/pkg/ethtypes/hexbytes_test.go
@@ -92,13 +92,13 @@ func TestHexByteConstructors(t *testing.T) {
 }
 
 func TestHexByteEqual(t *testing.T) {
-	assert.True(t, HexBytesPlain(nil).Equal(nil))
-	assert.False(t, HexBytesPlain(nil).Equal(HexBytesPlain{0x00}))
-	assert.False(t, (HexBytesPlain{0x00}).Equal(nil))
-	assert.True(t, (HexBytesPlain{0x00}).Equal(HexBytesPlain{0x00}))
+	assert.True(t, HexBytesPlain(nil).Equals(nil))
+	assert.False(t, HexBytesPlain(nil).Equals(HexBytesPlain{0x00}))
+	assert.False(t, (HexBytesPlain{0x00}).Equals(nil))
+	assert.True(t, (HexBytesPlain{0x00}).Equals(HexBytesPlain{0x00}))
 
-	assert.True(t, HexBytes0xPrefix(nil).Equal(nil))
-	assert.False(t, HexBytes0xPrefix(nil).Equal(HexBytes0xPrefix{0x00}))
-	assert.False(t, (HexBytes0xPrefix{0x00}).Equal(nil))
-	assert.True(t, (HexBytes0xPrefix{0x00}).Equal(HexBytes0xPrefix{0x00}))
+	assert.True(t, HexBytes0xPrefix(nil).Equals(nil))
+	assert.False(t, HexBytes0xPrefix(nil).Equals(HexBytes0xPrefix{0x00}))
+	assert.False(t, (HexBytes0xPrefix{0x00}).Equals(nil))
+	assert.True(t, (HexBytes0xPrefix{0x00}).Equals(HexBytes0xPrefix{0x00}))
 }

--- a/pkg/ethtypes/hexuint64.go
+++ b/pkg/ethtypes/hexuint64.go
@@ -1,0 +1,85 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethtypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/hyperledger/firefly-common/pkg/i18n"
+)
+
+// HexUint64 is a positive integer - serializes to JSON as an 0x hex string (no leading zeros), and parses flexibly depending on the prefix (so 0x for hex, or base 10 for plain string / float64)
+type HexUint64 uint64
+
+func (h *HexUint64) String() string {
+	if h == nil {
+		return "0x0"
+	}
+	return "0x" + strconv.FormatUint(uint64(*h), 16)
+}
+
+func (h HexUint64) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, h.String())), nil
+}
+
+func (h *HexUint64) UnmarshalJSON(b []byte) error {
+	var i interface{}
+	_ = json.Unmarshal(b, &i)
+	switch i := i.(type) {
+	case float64:
+		*h = HexUint64(i)
+		return nil
+	case string:
+		i64, err := strconv.ParseUint(i, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer: %s", i)
+		}
+		*h = HexUint64(i64)
+		return nil
+	default:
+		return fmt.Errorf("unable to parse integer from type %T", i)
+	}
+}
+
+func (h HexUint64) Uint64() uint64 {
+	return uint64(h)
+}
+
+func (h *HexUint64) Uint64OrZero() uint64 {
+	if h == nil {
+		return 0
+	}
+	return uint64(*h)
+}
+
+func (h *HexUint64) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case nil:
+		return nil
+	case int64:
+		*h = HexUint64(src)
+		return nil
+	case uint64:
+		*h = HexUint64(src)
+		return nil
+	default:
+		return i18n.NewError(context.Background(), i18n.MsgTypeRestoreFailed, src, h)
+	}
+}

--- a/pkg/ethtypes/hexuint64_test.go
+++ b/pkg/ethtypes/hexuint64_test.go
@@ -1,0 +1,136 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethtypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexUint64Ok(t *testing.T) {
+
+	testStruct := struct {
+		I1 *HexUint64 `json:"i1"`
+		I2 *HexUint64 `json:"i2"`
+		I3 *HexUint64 `json:"i3"`
+		I4 *HexUint64 `json:"i4"`
+		I5 *HexUint64 `json:"i5,omitempty"`
+	}{}
+
+	testData := `{
+		"i1": "0xabcd1234",
+		"i2": "54321",
+		"i3": 12345
+	}`
+
+	err := json.Unmarshal([]byte(testData), &testStruct)
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint64(0xabcd1234), testStruct.I1.Uint64())
+	assert.Equal(t, uint64(0xabcd1234), testStruct.I1.Uint64OrZero())
+	assert.Equal(t, uint64(54321), testStruct.I2.Uint64())
+	assert.Equal(t, uint64(12345), testStruct.I3.Uint64())
+	assert.Nil(t, testStruct.I4)
+	assert.Equal(t, uint64(0), testStruct.I4.Uint64OrZero()) // BigInt() safe on nils
+	assert.Equal(t, "0x0", testStruct.I4.String())
+	assert.Nil(t, testStruct.I5)
+	assert.Equal(t, uint64(12345), testStruct.I3.Uint64())
+
+	jsonSerialized, err := json.Marshal(&testStruct)
+	assert.JSONEq(t, `{
+		"i1": "0xabcd1234",
+		"i2": "0xd431",
+		"i3": "0x3039",
+		"i4": null
+	}`, string(jsonSerialized))
+
+}
+
+func TestHexUint64MissingBytes(t *testing.T) {
+
+	testStruct := struct {
+		I1 HexUint64 `json:"i1"`
+	}{}
+
+	testData := `{
+		"i1": "0x"
+	}`
+
+	err := json.Unmarshal([]byte(testData), &testStruct)
+	assert.Regexp(t, "unable to parse integer", err)
+}
+
+func TestHexUint64BadType(t *testing.T) {
+
+	testStruct := struct {
+		I1 HexUint64 `json:"i1"`
+	}{}
+
+	testData := `{
+		"i1": {}
+	}`
+
+	err := json.Unmarshal([]byte(testData), &testStruct)
+	assert.Regexp(t, "unable to parse integer", err)
+}
+
+func TestHexUint64BadJSON(t *testing.T) {
+
+	testStruct := struct {
+		I1 HexUint64 `json:"i1"`
+	}{}
+
+	testData := `{
+		"i1": null
+	}`
+
+	err := json.Unmarshal([]byte(testData), &testStruct)
+	assert.Error(t, err)
+}
+
+func TestHexUint64BadNegative(t *testing.T) {
+
+	testStruct := struct {
+		I1 HexUint64 `json:"i1"`
+	}{}
+
+	testData := `{
+		"i1": "-12345"
+	}`
+
+	err := json.Unmarshal([]byte(testData), &testStruct)
+	assert.Regexp(t, "parse", err)
+}
+
+func TestHexUint64Constructor(t *testing.T) {
+	assert.Equal(t, uint64(12345), HexUint64(12345).Uint64())
+}
+
+func TestScanUint64(t *testing.T) {
+	var i HexUint64
+	pI := &i
+	err := pI.Scan(false)
+	err = pI.Scan(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x0", pI.String())
+	pI.Scan(int64(5555))
+	assert.Equal(t, "0x15b3", pI.String())
+	pI.Scan(uint64(9999))
+	assert.Equal(t, "0x270f", pI.String())
+}

--- a/pkg/keystorev3/aes128ctr.go
+++ b/pkg/keystorev3/aes128ctr.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -44,9 +44,9 @@ func (w *walletFilePbkdf2) decrypt(password []byte) (err error) {
 
 	derivedKey := pbkdf2.Key(password, w.Crypto.KDFParams.Salt, w.Crypto.KDFParams.C, w.Crypto.KDFParams.DKLen, sha256.New)
 
-	privateKey, err := w.Crypto.decryptCommon(derivedKey)
+	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
 	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(privateKey)
+		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
 	}
 	return err
 

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -47,14 +47,13 @@ func mustGenerateDerivedScryptKey(password string, salt []byte, n, p int) []byte
 
 // creates an ethereum address wallet file
 func newScryptWalletFile(password string, keypair *secp256k1.KeyPair, n int, p int) WalletFile {
-	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), n, p)
-	wf.Address = ethtypes.AddressPlainHex(keypair.Address)
+	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), ethtypes.AddressPlainHex(keypair.Address), n, p)
 	wf.keypair = keypair
 	return wf
 }
 
 // this allows creation of any size/type of key in the store
-func newScryptWalletFileBytes(password string, privateKey []byte, n int, p int) *walletFileScrypt {
+func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.AddressPlainHex, n int, p int) *walletFileScrypt {
 
 	// Generate a sale for the scrypt
 	salt := mustReadBytes(32, rand.Reader)
@@ -77,6 +76,7 @@ func newScryptWalletFileBytes(password string, privateKey []byte, n int, p int) 
 	return &walletFileScrypt{
 		walletFileBase: walletFileBase{
 			ID:         fftypes.NewUUID(),
+			Address:    addr,
 			Version:    version3,
 			privateKey: privateKey,
 		},

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -98,9 +98,9 @@ func (w *walletFileScrypt) decrypt(password []byte) error {
 	if err != nil {
 		return fmt.Errorf("invalid scrypt keystore: %s", err)
 	}
-	privateKey, err := w.Crypto.decryptCommon(derivedKey)
+	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
 	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(privateKey)
+		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
 	}
 	return err
 }

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -39,6 +39,14 @@ func NewWalletFileStandard(password string, keypair *secp256k1.KeyPair) WalletFi
 	return newScryptWalletFile(password, keypair, nStandard, pDefault)
 }
 
+func NewWalletFileCustomBytesLight(password string, privateKey []byte) WalletFile {
+	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
+}
+
+func NewWalletFileCustomBytesStandard(password string, privateKey []byte) WalletFile {
+	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
+}
+
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
 	var w walletFileCommon
 	if err := json.Unmarshal(jsonWallet, &w); err != nil {

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/sha3"
 )
@@ -39,12 +40,20 @@ func NewWalletFileStandard(password string, keypair *secp256k1.KeyPair) WalletFi
 	return newScryptWalletFile(password, keypair, nStandard, pDefault)
 }
 
+func addressFirst32(privateKey []byte) ethtypes.AddressPlainHex {
+	if len(privateKey) > 32 {
+		privateKey = privateKey[0:32]
+	}
+	kp, _ := secp256k1.NewSecp256k1KeyPair(privateKey)
+	return ethtypes.AddressPlainHex(kp.Address)
+}
+
 func NewWalletFileCustomBytesLight(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
 }
 
 func NewWalletFileCustomBytesStandard(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
 }
 
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {

--- a/pkg/keystorev3/wallet_test.go
+++ b/pkg/keystorev3/wallet_test.go
@@ -123,3 +123,33 @@ func TestWalletFilePbkdf2JSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, w, w2)
 }
+
+func TestWalletFileCustomBytes(t *testing.T) {
+	customBytes := ([]byte)("planet refuse wheel robot position venue predict bring solid paper salmon bind")
+
+	w := NewWalletFileCustomBytesStandard("correcthorsebatterystaple", customBytes)
+
+	w, err := ReadWalletFile(w.JSON(), []byte("correcthorsebatterystaple"))
+	assert.NoError(t, err)
+	j := w.JSON()
+	w2, err := ReadWalletFile(j, []byte("correcthorsebatterystaple"))
+	assert.NoError(t, err)
+	assert.Equal(t, w, w2)
+
+	assert.Equal(t, customBytes, w.PrivateKey())
+}
+
+func TestWalletFileCustomBytesLight(t *testing.T) {
+	customBytes := ([]byte)("planet refuse wheel robot position venue predict bring solid paper salmon bind")
+
+	w := NewWalletFileCustomBytesLight("correcthorsebatterystaple", customBytes)
+
+	w, err := ReadWalletFile(w.JSON(), []byte("correcthorsebatterystaple"))
+	assert.NoError(t, err)
+	j := w.JSON()
+	w2, err := ReadWalletFile(j, []byte("correcthorsebatterystaple"))
+	assert.NoError(t, err)
+	assert.Equal(t, w, w2)
+
+	assert.Equal(t, customBytes, w.PrivateKey())
+}

--- a/pkg/keystorev3/wallet_test.go
+++ b/pkg/keystorev3/wallet_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"testing/iotest"
 
+	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -137,10 +138,15 @@ func TestWalletFileCustomBytes(t *testing.T) {
 	assert.Equal(t, w, w2)
 
 	assert.Equal(t, customBytes, w.PrivateKey())
+
+	first32 := ([]byte)("planet refuse wheel robot positi")
+	kp, _ := secp256k1.NewSecp256k1KeyPair(first32)
+	assert.NoError(t, err)
+	assert.Equal(t, kp.Address, w2.KeyPair().Address)
 }
 
 func TestWalletFileCustomBytesLight(t *testing.T) {
-	customBytes := ([]byte)("planet refuse wheel robot position venue predict bring solid paper salmon bind")
+	customBytes := ([]byte)("less than 32 bytes")
 
 	w := NewWalletFileCustomBytesLight("correcthorsebatterystaple", customBytes)
 
@@ -152,4 +158,9 @@ func TestWalletFileCustomBytesLight(t *testing.T) {
 	assert.Equal(t, w, w2)
 
 	assert.Equal(t, customBytes, w.PrivateKey())
+
+	zeroToTheRight := ([]byte)("less than 32 bytes")
+	kp, _ := secp256k1.NewSecp256k1KeyPair(zeroToTheRight)
+	assert.NoError(t, err)
+	assert.Equal(t, kp.Address, w2.KeyPair().Address)
 }

--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,6 +34,7 @@ const (
 )
 
 type WalletFile interface {
+	PrivateKey() []byte
 	KeyPair() *secp256k1.KeyPair
 	JSON() []byte
 }
@@ -80,7 +81,8 @@ type walletFileBase struct {
 	ID      *fftypes.UUID            `json:"id"`
 	Version int                      `json:"version"`
 
-	keypair *secp256k1.KeyPair
+	privateKey []byte
+	keypair    *secp256k1.KeyPair
 }
 
 type walletFileCommon struct {
@@ -100,6 +102,10 @@ type walletFileScrypt struct {
 
 func (w *walletFileBase) KeyPair() *secp256k1.KeyPair {
 	return w.keypair
+}
+
+func (w *walletFileBase) PrivateKey() []byte {
+	return w.privateKey
 }
 
 func (w *walletFilePbkdf2) JSON() []byte {

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -343,12 +343,14 @@ func (rc *wsRPCClient) Subscriptions() []Subscription {
 }
 
 func (rc *wsRPCClient) sendRPC(ctx context.Context, reqID string, rpcReq *RPCRequest) *RPCError {
-	jsonInput, _ := json.Marshal(rpcReq)
-	log.L(ctx).Debugf("RPC[%s] --> %s", reqID, rpcReq.Method)
-	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		log.L(ctx).Tracef("RPC[%s] INPUT: %s", reqID, jsonInput)
+	jsonInput, err := json.Marshal(rpcReq)
+	if err == nil {
+		log.L(ctx).Debugf("RPC[%s] --> %s", reqID, rpcReq.Method)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			log.L(ctx).Tracef("RPC[%s] INPUT: %s", reqID, jsonInput)
+		}
+		err = rc.client.Send(ctx, jsonInput)
 	}
-	err := rc.client.Send(ctx, jsonInput)
 	if err != nil {
 		rpcErr := NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgRPCRequestFailed, err)
 		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, err)

--- a/pkg/secp256k1/signer.go
+++ b/pkg/secp256k1/signer.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/signer.go
+++ b/pkg/secp256k1/signer.go
@@ -69,7 +69,10 @@ func (s *SignatureData) UpdateEIP155(chainID int64) {
 
 // EIP-2930 (/ EIP-1559) rules - 0 or 1 V value for raw Y-parity value (chainID goes into the payload)
 func (s *SignatureData) UpdateEIP2930() {
-	s.V = s.V.Sub(s.V, big.NewInt(27))
+	vi64 := s.V.Int64()
+	if vi64 == 27 || vi64 == 28 {
+		s.V = s.V.Sub(s.V, big.NewInt(27))
+	}
 }
 
 // Recover obtains the original signer from the hash of the message


### PR DESCRIPTION
- Allows use of the EIP-712 hashing algorithm for the data itself, without needing to also supply a domin.
- Allows querying `M` and `N` dimensions of parsed Elementary Types
- Fixes issue where we could have a `Component` array containing a nil entry on the case of extra parameters on input
- Allows `Recover` functions to determine the original payload of the transactions, as well as the recovered signature
- Allows raw signing key access, as well as `secp256k1` curve-adapted access, to private key materials from `keystorev3`
- Ensures errors from serializing inputs are returned