### PR TITLE
Make keystorev3 wallets curve-agnostic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require github.com/dchest/blake512 v1.0.0 // indirect
+
 require (
 	github.com/aidarkhanov/nanoid v1.0.8 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -34,6 +36,7 @@ require (
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/iden3/go-iden3-crypto v0.0.16
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake512 v1.0.0 h1:oDFEQFIqFSeuA34xLtXZ/rWxCXdSjirjzPhey5EUvmA=
+github.com/dchest/blake512 v1.0.0/go.mod h1:FV1x7xPPLWukZlpDpWQ88rF/SFwZ5qbskrzhLMB92JI=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
@@ -48,6 +50,8 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hyperledger/firefly-common v1.4.6 h1:qqXoSaRml3WjUnWcWxrrXs5AIOWa+UcMXLCF8yEa4Pk=
 github.com/hyperledger/firefly-common v1.4.6/go.mod h1:jkErZdQmC9fsAJZQO427tURdwB9iiW+NMUZSqS3eBIE=
+github.com/iden3/go-iden3-crypto v0.0.16 h1:zN867xiz6HgErXVIV/6WyteGcOukE9gybYTorBMEdsk=
+github.com/iden3/go-iden3-crypto v0.0.16/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=

--- a/pkg/fswallet/fslistener_test.go
+++ b/pkg/fswallet/fslistener_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
+	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -85,7 +86,9 @@ func TestFileListener(t *testing.T) {
 	addr := *ethtypes.MustNewAddress(`1f185718734552d08278aa70f804580bab5fd2b4`)
 	wf, err := f.GetWalletFile(ctx, addr)
 	assert.NoError(t, err)
-	assert.Equal(t, wf.KeyPair().Address, addr)
+	keypair, err := secp256k1.NewSecp256k1KeyPair(wf.PrivateKey())
+	assert.NoError(t, err)
+	assert.Equal(t, keypair.Address, addr)
 
 }
 

--- a/pkg/fswallet/fswallet.go
+++ b/pkg/fswallet/fswallet.go
@@ -259,7 +259,7 @@ func (w *fsWallet) getSignerForAddr(ctx context.Context, from ethtypes.Address0x
 	if err != nil {
 		return nil, err
 	}
-	return wf.KeyPair(), nil
+	return secp256k1.NewSecp256k1KeyPair(wf.PrivateKey())
 
 }
 
@@ -284,7 +284,10 @@ func (w *fsWallet) GetWalletFile(ctx context.Context, addr ethtypes.Address0xHex
 		return nil, err
 	}
 
-	keypair := kv3.KeyPair()
+	keypair, err := secp256k1.NewSecp256k1KeyPair(kv3.PrivateKey())
+	if err != nil {
+		return nil, i18n.NewError(ctx, signermsgs.MsgWalletFailed, addr)
+	}
 	if keypair.Address != addr {
 		return nil, i18n.NewError(ctx, signermsgs.MsgAddressMismatch, keypair.Address, addr)
 	}

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -45,9 +44,6 @@ func (w *walletFilePbkdf2) decrypt(password []byte) (err error) {
 	derivedKey := pbkdf2.Key(password, w.Crypto.KDFParams.Salt, w.Crypto.KDFParams.C, w.Crypto.KDFParams.DKLen, sha256.New)
 
 	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
-	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
-	}
 	return err
 
 }

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
-	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
+	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/pbkdf2"
 )
 
-func TestPbkdf2Wallet(t *testing.T) {
+func TestPbkdf2WalletForSecp256k1(t *testing.T) {
 	keypair, err := secp256k1.GenerateSecp256k1KeyPair()
 	assert.NoError(t, err)
 
@@ -42,10 +42,9 @@ func TestPbkdf2Wallet(t *testing.T) {
 
 	w1 := &walletFilePbkdf2{
 		walletFileBase: walletFileBase{
-			Address: ethtypes.AddressPlainHex(keypair.Address),
+			Address: keypair.Address.String(),
 			ID:      fftypes.NewUUID(),
 			Version: version3,
-			keypair: keypair,
 		},
 		Crypto: cryptoPbkdf2{
 			cryptoCommon: cryptoCommon{
@@ -72,7 +71,56 @@ func TestPbkdf2Wallet(t *testing.T) {
 	w2, err := ReadWalletFile(wb1, []byte("myPrecious"))
 	assert.NoError(t, err)
 
-	assert.Equal(t, keypair.PrivateKeyBytes(), w2.KeyPair().PrivateKeyBytes())
+	assert.Equal(t, keypair.PrivateKeyBytes(), w2.PrivateKey())
+
+}
+
+func TestPbkdf2WalletForBabyjubjub(t *testing.T) {
+	privKey := babyjub.NewRandPrivKey()
+	pubKey := privKey.Public()
+
+	salt := mustReadBytes(32, rand.Reader)
+	derivedKey := pbkdf2.Key([]byte("myPrecious"), salt, 4096, 32, sha256.New)
+	iv := mustReadBytes(16 /* 128bit */, rand.Reader)
+	encryptKey := derivedKey[0:16]
+	cipherText := mustAES128CtrEncrypt(encryptKey, iv, privKey[:])
+	mac := generateMac(derivedKey[16:32], cipherText)
+
+	w1 := &walletFilePbkdf2{
+		walletFileBase: walletFileBase{
+			Address: pubKey.Compress().String(),
+			ID:      fftypes.NewUUID(),
+			Version: version3,
+		},
+		Crypto: cryptoPbkdf2{
+			cryptoCommon: cryptoCommon{
+				Cipher:     cipherAES128ctr,
+				CipherText: cipherText,
+				CipherParams: cipherParams{
+					IV: iv,
+				},
+				KDF: kdfTypePbkdf2,
+				MAC: mac,
+			},
+			KDFParams: kdfParamsPbkdf2{
+				PRF:   prfHmacSHA256,
+				DKLen: 32,
+				C:     4096,
+				Salt:  salt,
+			},
+		},
+	}
+
+	wb1, err := json.Marshal(&w1)
+	assert.NoError(t, err)
+
+	w2, err := ReadWalletFile(wb1, []byte("myPrecious"))
+	assert.NoError(t, err)
+
+	var recoveredPrivKey babyjub.PrivateKey
+	copy(recoveredPrivKey[:], w2.PrivateKey())
+
+	assert.Equal(t, recoveredPrivKey.Public().Compress(), pubKey.Compress())
 
 }
 

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
-	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
-	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/scrypt"
 )
 
@@ -46,14 +44,13 @@ func mustGenerateDerivedScryptKey(password string, salt []byte, n, p int) []byte
 }
 
 // creates an ethereum address wallet file
-func newScryptWalletFile(password string, keypair *secp256k1.KeyPair, n int, p int) WalletFile {
-	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), ethtypes.AddressPlainHex(keypair.Address), n, p)
-	wf.keypair = keypair
+func newScryptWalletFile(password string, privateKeyBytes []byte, addr string, n int, p int) WalletFile {
+	wf := newScryptWalletFileBytes(password, privateKeyBytes, addr, n, p)
 	return wf
 }
 
 // this allows creation of any size/type of key in the store
-func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.AddressPlainHex, n int, p int) *walletFileScrypt {
+func newScryptWalletFileBytes(password string, privateKey []byte, addr string, n int, p int) *walletFileScrypt {
 
 	// Generate a sale for the scrypt
 	salt := mustReadBytes(32, rand.Reader)
@@ -107,8 +104,5 @@ func (w *walletFileScrypt) decrypt(password []byte) error {
 		return fmt.Errorf("invalid scrypt keystore: %s", err)
 	}
 	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
-	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
-	}
 	return err
 }

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -32,12 +32,12 @@ const (
 	pDefault  int = 1
 )
 
-func NewWalletFileLight(password string, keypair *secp256k1.KeyPair) WalletFile {
-	return newScryptWalletFile(password, keypair, nLight, pDefault)
+func NewWalletFileLight(password string, privateKey []byte, addr string) WalletFile {
+	return newScryptWalletFile(password, privateKey, addr, nLight, pDefault)
 }
 
-func NewWalletFileStandard(password string, keypair *secp256k1.KeyPair) WalletFile {
-	return newScryptWalletFile(password, keypair, nStandard, pDefault)
+func NewWalletFileStandard(password string, privateKey []byte, addr string) WalletFile {
+	return newScryptWalletFile(password, privateKey, addr, nStandard, pDefault)
 }
 
 func addressFirst32(privateKey []byte) ethtypes.AddressPlainHex {
@@ -49,11 +49,11 @@ func addressFirst32(privateKey []byte) ethtypes.AddressPlainHex {
 }
 
 func NewWalletFileCustomBytesLight(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey).String(), nStandard, pDefault)
 }
 
 func NewWalletFileCustomBytesStandard(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey).String(), nStandard, pDefault)
 }
 
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {

--- a/pkg/keystorev3/wallet_test.go
+++ b/pkg/keystorev3/wallet_test.go
@@ -75,7 +75,8 @@ func TestLoadSampleWallet(t *testing.T) {
 	w, err := ReadWalletFile([]byte(sampleWallet), []byte("correcthorsebatterystaple"))
 	assert.NoError(t, err)
 
-	keypair := w.KeyPair()
+	keypair, err := secp256k1.NewSecp256k1KeyPair(w.PrivateKey())
+	assert.NoError(t, err)
 	assert.Equal(t, samplePrivateKey, hex.EncodeToString(keypair.PrivateKeyBytes()))
 }
 
@@ -136,13 +137,14 @@ func TestWalletFileCustomBytes(t *testing.T) {
 	w2, err := ReadWalletFile(j, []byte("correcthorsebatterystaple"))
 	assert.NoError(t, err)
 	assert.Equal(t, w, w2)
+	keypair, err := secp256k1.NewSecp256k1KeyPair(w.PrivateKey())
 
 	assert.Equal(t, customBytes, w.PrivateKey())
 
 	first32 := ([]byte)("planet refuse wheel robot positi")
 	kp, _ := secp256k1.NewSecp256k1KeyPair(first32)
 	assert.NoError(t, err)
-	assert.Equal(t, kp.Address, w2.KeyPair().Address)
+	assert.Equal(t, kp.Address, keypair.Address)
 }
 
 func TestWalletFileCustomBytesLight(t *testing.T) {
@@ -156,11 +158,12 @@ func TestWalletFileCustomBytesLight(t *testing.T) {
 	w2, err := ReadWalletFile(j, []byte("correcthorsebatterystaple"))
 	assert.NoError(t, err)
 	assert.Equal(t, w, w2)
+	keypair, err := secp256k1.NewSecp256k1KeyPair(w.PrivateKey())
 
 	assert.Equal(t, customBytes, w.PrivateKey())
 
 	zeroToTheRight := ([]byte)("less than 32 bytes")
 	kp, _ := secp256k1.NewSecp256k1KeyPair(zeroToTheRight)
 	assert.NoError(t, err)
-	assert.Equal(t, kp.Address, w2.KeyPair().Address)
+	assert.Equal(t, kp.Address, keypair.Address)
 }

--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
-	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 )
 
 const (
@@ -33,9 +32,13 @@ const (
 	kdfTypePbkdf2   = "pbkdf2"
 )
 
+// WalletFile is the interface for a general-purpose wallet file
+// that can be used to store a private key with encryption. It is
+// agnostic of the public key algorithm used to derive the public
+// key from the private key. This can be used with, for instance,
+// various Elliptic Curve algorithms such as secp256k1, Baby Jubjub.
 type WalletFile interface {
 	PrivateKey() []byte
-	KeyPair() *secp256k1.KeyPair
 	JSON() []byte
 }
 
@@ -77,12 +80,11 @@ type cryptoPbkdf2 struct {
 }
 
 type walletFileBase struct {
-	Address ethtypes.AddressPlainHex `json:"address"`
-	ID      *fftypes.UUID            `json:"id"`
-	Version int                      `json:"version"`
+	Address string        `json:"address"`
+	ID      *fftypes.UUID `json:"id"`
+	Version int           `json:"version"`
 
 	privateKey []byte
-	keypair    *secp256k1.KeyPair
 }
 
 type walletFileCommon struct {
@@ -98,10 +100,6 @@ type walletFilePbkdf2 struct {
 type walletFileScrypt struct {
 	walletFileBase
 	Crypto cryptoScrypt `json:"crypto"`
-}
-
-func (w *walletFileBase) KeyPair() *secp256k1.KeyPair {
-	return w.keypair
 }
 
 func (w *walletFileBase) PrivateKey() []byte {


### PR DESCRIPTION
Make the implementation in the `pkg/keystorev3` package agnostic of public key curves, and only manages the private key bytes with encryption and decryption in persistence.

Ideally the `pkg/fswallet` is also made curve agnostic, but that's the main API used by downstream client code and the Ethereum's 20-byte address is already entrenched. For a different system like Babyjubjub, in particular the implementation in `https://github.com/iden3/go-iden3-crypto`, the public key compression format is 32 bytes. So the right approach for now is build a parallel implementation of the fswallet somewhere else