### PR TITLE
Allow additional/override of non-spec fields, including "address"

### DIFF
--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -29,11 +29,12 @@ const (
 	prfHmacSHA256 = "hmac-sha256"
 )
 
-func readPbkdf2WalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
+func readPbkdf2WalletFile(jsonWallet []byte, password []byte, metadata map[string]interface{}) (WalletFile, error) {
 	var w *walletFilePbkdf2
 	if err := json.Unmarshal(jsonWallet, &w); err != nil {
 		return nil, fmt.Errorf("invalid pbkdf2 keystore: %s", err)
 	}
+	w.metadata = metadata
 	return w, w.decrypt(password)
 }
 

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -46,9 +45,6 @@ func (w *walletFilePbkdf2) decrypt(password []byte) (err error) {
 	derivedKey := pbkdf2.Key(password, w.Crypto.KDFParams.Salt, w.Crypto.KDFParams.C, w.Crypto.KDFParams.DKLen, sha256.New)
 
 	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
-	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
-	}
 	return err
 
 }

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -42,9 +42,13 @@ func TestPbkdf2Wallet(t *testing.T) {
 
 	w1 := &walletFilePbkdf2{
 		walletFileBase: walletFileBase{
-			Address: ethtypes.AddressPlainHex(keypair.Address),
-			ID:      fftypes.NewUUID(),
-			Version: version3,
+			walletFileCoreFields: walletFileCoreFields{
+				ID:      fftypes.NewUUID(),
+				Version: version3,
+			},
+			walletFileMetadata: walletFileMetadata{
+				Address: ethtypes.AddressPlainHex(keypair.Address),
+			},
 			keypair: keypair,
 		},
 		Crypto: cryptoPbkdf2{
@@ -78,14 +82,14 @@ func TestPbkdf2Wallet(t *testing.T) {
 
 func TestPbkdf2WalletFileDecryptInvalid(t *testing.T) {
 
-	_, err := readPbkdf2WalletFile([]byte(`!! not json`), []byte(""))
+	_, err := readPbkdf2WalletFile([]byte(`!! not json`), []byte(""), nil)
 	assert.Regexp(t, "invalid pbkdf2 keystore", err)
 
 }
 
 func TestPbkdf2WalletFileUnsupportedPRF(t *testing.T) {
 
-	_, err := readPbkdf2WalletFile([]byte(`{}`), []byte(""))
+	_, err := readPbkdf2WalletFile([]byte(`{}`), []byte(""), nil)
 	assert.Regexp(t, "invalid pbkdf2 wallet file: unsupported prf", err)
 
 }

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -47,9 +47,10 @@ func TestPbkdf2Wallet(t *testing.T) {
 				Version: version3,
 			},
 			walletFileMetadata: walletFileMetadata{
-				Address: ethtypes.AddressPlainHex(keypair.Address),
+				metadata: map[string]interface{}{
+					"address": ethtypes.AddressPlainHex(keypair.Address).String(),
+				},
 			},
-			keypair: keypair,
 		},
 		Crypto: cryptoPbkdf2{
 			cryptoCommon: cryptoCommon{

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -47,14 +47,14 @@ func mustGenerateDerivedScryptKey(password string, salt []byte, n, p int) []byte
 }
 
 // creates an ethereum address wallet file
-func newScryptWalletFile(password string, keypair *secp256k1.KeyPair, n int, p int) WalletFile {
-	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), ethtypes.AddressPlainHex(keypair.Address), n, p)
-	wf.keypair = keypair
+func newScryptWalletFileSecp256k1(password string, keypair *secp256k1.KeyPair, n int, p int) WalletFile {
+	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), n, p)
+	wf.Metadata()["address"] = ethtypes.AddressPlainHex(keypair.Address).String()
 	return wf
 }
 
 // this allows creation of any size/type of key in the store
-func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.AddressPlainHex, n int, p int) *walletFileScrypt {
+func newScryptWalletFileBytes(password string, privateKey []byte, n int, p int) *walletFileScrypt {
 
 	// Generate a sale for the scrypt
 	salt := mustReadBytes(32, rand.Reader)
@@ -81,7 +81,6 @@ func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.
 				Version: version3,
 			},
 			walletFileMetadata: walletFileMetadata{
-				Address:  addr,
 				metadata: map[string]interface{}{},
 			},
 			privateKey: privateKey,
@@ -113,8 +112,5 @@ func (w *walletFileScrypt) decrypt(password []byte) error {
 		return fmt.Errorf("invalid scrypt keystore: %s", err)
 	}
 	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
-	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
-	}
 	return err
 }

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -29,11 +29,12 @@ import (
 
 const defaultR = 8
 
-func readScryptWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
+func readScryptWalletFile(jsonWallet []byte, password []byte, metadata map[string]interface{}) (WalletFile, error) {
 	var w *walletFileScrypt
 	if err := json.Unmarshal(jsonWallet, &w); err != nil {
 		return nil, fmt.Errorf("invalid scrypt wallet file: %s", err)
 	}
+	w.metadata = metadata
 	return w, w.decrypt(password)
 }
 
@@ -75,9 +76,14 @@ func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.
 
 	return &walletFileScrypt{
 		walletFileBase: walletFileBase{
-			ID:         fftypes.NewUUID(),
-			Address:    addr,
-			Version:    version3,
+			walletFileCoreFields: walletFileCoreFields{
+				ID:      fftypes.NewUUID(),
+				Version: version3,
+			},
+			walletFileMetadata: walletFileMetadata{
+				Address:  addr,
+				metadata: map[string]interface{}{},
+			},
 			privateKey: privateKey,
 		},
 		Crypto: cryptoScrypt{

--- a/pkg/keystorev3/scrypt_test.go
+++ b/pkg/keystorev3/scrypt_test.go
@@ -58,7 +58,7 @@ func TestScryptWalletRoundTripStandard(t *testing.T) {
 
 func TestScryptReadInvalidFile(t *testing.T) {
 
-	_, err := readScryptWalletFile([]byte(`!bad JSON`), []byte(""))
+	_, err := readScryptWalletFile([]byte(`!bad JSON`), []byte(""), nil)
 	assert.Error(t, err)
 
 }

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -58,7 +58,11 @@ func NewWalletFileCustomBytesStandard(password string, privateKey []byte) Wallet
 
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
 	var w walletFileCommon
-	if err := json.Unmarshal(jsonWallet, &w); err != nil {
+	err := json.Unmarshal(jsonWallet, &w)
+	if err == nil {
+		err = json.Unmarshal(jsonWallet, &w.metadata)
+	}
+	if err != nil {
 		return nil, fmt.Errorf("invalid wallet file: %s", err)
 	}
 	if w.ID == nil {
@@ -69,9 +73,9 @@ func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
 	}
 	switch w.Crypto.KDF {
 	case kdfTypeScrypt:
-		return readScryptWalletFile(jsonWallet, password)
+		return readScryptWalletFile(jsonWallet, password, w.metadata)
 	case kdfTypePbkdf2:
-		return readPbkdf2WalletFile(jsonWallet, password)
+		return readPbkdf2WalletFile(jsonWallet, password, w.metadata)
 	default:
 		return nil, fmt.Errorf("unsupported kdf: %s", w.Crypto.KDF)
 	}

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/sha3"
 )
@@ -33,27 +32,19 @@ const (
 )
 
 func NewWalletFileLight(password string, keypair *secp256k1.KeyPair) WalletFile {
-	return newScryptWalletFile(password, keypair, nLight, pDefault)
+	return newScryptWalletFileSecp256k1(password, keypair, nLight, pDefault)
 }
 
 func NewWalletFileStandard(password string, keypair *secp256k1.KeyPair) WalletFile {
-	return newScryptWalletFile(password, keypair, nStandard, pDefault)
-}
-
-func addressFirst32(privateKey []byte) ethtypes.AddressPlainHex {
-	if len(privateKey) > 32 {
-		privateKey = privateKey[0:32]
-	}
-	kp, _ := secp256k1.NewSecp256k1KeyPair(privateKey)
-	return ethtypes.AddressPlainHex(kp.Address)
+	return newScryptWalletFileSecp256k1(password, keypair, nStandard, pDefault)
 }
 
 func NewWalletFileCustomBytesLight(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
 }
 
 func NewWalletFileCustomBytesStandard(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
 }
 
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {

--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -92,8 +92,6 @@ type walletFileCoreFields struct {
 }
 
 type walletFileMetadata struct {
-	// address is not technically part of keystorev3 syntax, and note this can be overridden/removed by callers of the package
-	Address ethtypes.AddressPlainHex `json:"address"`
 	// arbitrary additional fields that can be stored in the JSON, including overriding/removing the "address" field (other core fields cannot be overridden)
 	metadata map[string]interface{}
 }
@@ -102,7 +100,6 @@ type walletFileBase struct {
 	walletFileCoreFields
 	walletFileMetadata
 	privateKey []byte
-	keypair    *secp256k1.KeyPair
 }
 
 type walletFileCommon struct {
@@ -146,12 +143,8 @@ func marshalWalletJSON(wc *walletFileBase, crypto interface{}) ([]byte, error) {
 		return nil, err
 	}
 	jsonMap := map[string]interface{}{}
-	// note address can be set to "nil" to remove it entirely
-	jsonMap["address"] = wc.Address
 	for k, v := range wc.metadata {
-		if v == nil {
-			delete(jsonMap, k)
-		} else {
+		if v != nil {
 			jsonMap[k] = v
 		}
 	}
@@ -163,7 +156,7 @@ func marshalWalletJSON(wc *walletFileBase, crypto interface{}) ([]byte, error) {
 }
 
 func (w *walletFileBase) KeyPair() *secp256k1.KeyPair {
-	return w.keypair
+	return secp256k1.KeyPairFromBytes(w.privateKey)
 }
 
 func (w *walletFileBase) PrivateKey() []byte {

--- a/pkg/secp256k1/keypair.go
+++ b/pkg/secp256k1/keypair.go
@@ -43,7 +43,7 @@ func GenerateSecp256k1KeyPair() (*KeyPair, error) {
 	return wrapSecp256k1Key(key, key.PubKey()), nil
 }
 
-// Note there is no error condition returned by this function (use KeyPairFromBytes)
+// Deprecated: Note there is no error condition returned by this function (use KeyPairFromBytes)
 func NewSecp256k1KeyPair(b []byte) (*KeyPair, error) {
 	key, pubKey := btcec.PrivKeyFromBytes(b)
 	return wrapSecp256k1Key(key, pubKey), nil

--- a/pkg/secp256k1/keypair.go
+++ b/pkg/secp256k1/keypair.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -43,9 +43,15 @@ func GenerateSecp256k1KeyPair() (*KeyPair, error) {
 	return wrapSecp256k1Key(key, key.PubKey()), nil
 }
 
+// Note there is no error condition returned by this function (use KeyPairFromBytes)
 func NewSecp256k1KeyPair(b []byte) (*KeyPair, error) {
 	key, pubKey := btcec.PrivKeyFromBytes(b)
 	return wrapSecp256k1Key(key, pubKey), nil
+}
+
+func KeyPairFromBytes(b []byte) *KeyPair {
+	key, pubKey := btcec.PrivKeyFromBytes(b)
+	return wrapSecp256k1Key(key, pubKey)
 }
 
 func wrapSecp256k1Key(key *btcec.PrivateKey, pubKey *btcec.PublicKey) *KeyPair {


### PR DESCRIPTION
As discussed in #69:
- The `address` field is **not** part of the Version 3 spec - was removed [here](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition#alterations-from-version-1) justification:
    > `Address` unnecessary and compromises privacy.
- The `address` field is a very Ethereum specific way to store a piece of metadata that is intended to identify the private key publicly
   - An `0x` prefixed 20 hex-byte compressed identifier of the SECP256K1 derivied public key, for the private key
- When this library is used to stored key materials for other curves/cryptogrpahy (as now supported since #68) its misleading

So...

This PR allows `WalletFile.Metadata()` to be called get a `map[string]any` that you can used to:
1. store arbitrary additional fields, like `bjjIdentifer` or `btcIdentifier` that are different public key representations of the private key
2. remove the `address` field from the serialization by setting it to `nil`

