### PR TITLE
Solidity defs

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -670,6 +670,63 @@ func (e *Entry) SignatureCtx(ctx context.Context) (string, error) {
 	return buff.String(), nil
 }
 
+func (e *Entry) SolidityDef() (string, []string, error) {
+	return e.SolidityDefCtx(context.Background())
+}
+
+// DescriptorStringCtx returns a Solidity-like descriptor of the entry, including its type
+func (e *Entry) SolidityDefCtx(ctx context.Context) (string, []string, error) {
+	// Everything apart from event and error is a type of function
+	isFunction := e.Type != Error && e.Type != Event
+
+	allChildStructs := []string{}
+	buff := new(strings.Builder)
+	buff.WriteString(string(e.Type))
+	buff.WriteRune(' ')
+	buff.WriteString(e.Name)
+	buff.WriteRune('(')
+	for i, p := range e.Inputs {
+		if i > 0 {
+			buff.WriteString(", ")
+		}
+		s, childStructs, err := p.SolidityDefCtx(ctx, isFunction)
+		if err != nil {
+			return "", nil, err
+		}
+		allChildStructs = append(allChildStructs, childStructs...)
+		buff.WriteString(s)
+	}
+	buff.WriteRune(')')
+
+	if isFunction {
+		buff.WriteString(" external")
+		if e.StateMutability != "" &&
+			// The state mutability nonpayable is reflected in Solidity by not specifying a state mutability modifier at all.
+			e.StateMutability != NonPayable {
+			buff.WriteRune(' ')
+			buff.WriteString(string(e.StateMutability))
+		}
+		if len(e.Outputs) > 0 {
+			buff.WriteString(" returns (")
+			for i, p := range e.Outputs {
+				if i > 0 {
+					buff.WriteString(", ")
+				}
+				s, childStructs, err := p.SolidityDefCtx(ctx, isFunction)
+				if err != nil {
+					return "", nil, err
+				}
+				allChildStructs = append(allChildStructs, childStructs...)
+				buff.WriteString(s)
+			}
+			buff.WriteRune(')')
+		}
+		buff.WriteString(" { }")
+	}
+
+	return buff.String(), allChildStructs, nil
+}
+
 // Validate processes all the components of the type of this ABI parameter.
 // - The elementary type
 // - The fixed/variable length array dimensions
@@ -699,6 +756,16 @@ func (p *Parameter) SignatureStringCtx(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return tc.String(), nil
+}
+
+func (p *Parameter) SolidityDefCtx(ctx context.Context, inFunction bool) (string, []string, error) {
+	// Ensure the type component tree has been parsed
+	tc, err := p.TypeComponentTreeCtx(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	solDef, childStructs := tc.SolidityParamDef(inFunction)
+	return solDef, childStructs, nil
 }
 
 // String returns the signature string. If a Validate needs to be initiated, and that

--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -252,7 +252,6 @@ func TestExampleABIDecode7(t *testing.T) {
 
 	// a tuple of dynamic types (which is the same as a fixed-length array of the dynamic types)
 	f := &Entry{
-		Name: "g",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple",
@@ -285,7 +284,7 @@ func TestExampleABIDecode7(t *testing.T) {
 func TestExampleABIDecodeTupleDifferentOrder(t *testing.T) {
 
 	f := &Entry{
-		Name: "coupon",
+		// Name: "coupon",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple[]",
@@ -316,7 +315,7 @@ func TestExampleABIDecodeTupleDifferentOrder(t *testing.T) {
 func TestExampleABIDecodeTuple(t *testing.T) {
 
 	f := &Entry{
-		Name: "coupon",
+		// Name: "coupon",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple[]",
@@ -351,7 +350,7 @@ func TestExampleABIDecodeTuple(t *testing.T) {
 func TestExampleABIDecodeNonDynamicTuple(t *testing.T) {
 
 	f := &Entry{
-		Name: "coupon",
+		// Name: "coupon",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple",
@@ -378,7 +377,7 @@ func TestExampleABIDecodeNonDynamicTuple(t *testing.T) {
 func TestExampleABIDecodeDoubleNestedTuple(t *testing.T) {
 
 	f := &Entry{
-		Name: "f",
+		// Name: "f",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple[]",
@@ -442,7 +441,7 @@ func TestExampleABIDecodeDoubleNestedTuple(t *testing.T) {
 func TestExampleABIDecodeStaticNestedTupleInDynamicTuple(t *testing.T) {
 
 	f := &Entry{
-		Name: "f",
+		// Name: "f",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple[]",
@@ -498,7 +497,7 @@ func TestExampleABIDecodeStaticNestedTupleInDynamicTuple(t *testing.T) {
 func TestExampleABIDecodeDoubleStaticNestedTuple(t *testing.T) {
 
 	f := &Entry{
-		Name: "f",
+		// Name: "f",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple[]",
@@ -548,7 +547,7 @@ func TestExampleABIDecodeDoubleStaticNestedTuple(t *testing.T) {
 func TestExampleABIDecodeTupleFixed(t *testing.T) {
 
 	f := &Entry{
-		Name: "coupon",
+		// Name: "coupon",
 		Outputs: ParameterArray{
 			{
 				Type: "tuple[1]",
@@ -573,7 +572,7 @@ func TestExampleABIDecode8(t *testing.T) {
 
 	// a fixed-length array of dynamic types
 	f := &Entry{
-		Name: "g",
+		// Name: "g",
 		Outputs: ParameterArray{
 			{Type: "string[2]"},
 		},

--- a/pkg/abi/abiencode.go
+++ b/pkg/abi/abiencode.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -29,11 +29,12 @@ const (
 	prfHmacSHA256 = "hmac-sha256"
 )
 
-func readPbkdf2WalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
+func readPbkdf2WalletFile(jsonWallet []byte, password []byte, metadata map[string]interface{}) (WalletFile, error) {
 	var w *walletFilePbkdf2
 	if err := json.Unmarshal(jsonWallet, &w); err != nil {
 		return nil, fmt.Errorf("invalid pbkdf2 keystore: %s", err)
 	}
+	w.metadata = metadata
 	return w, w.decrypt(password)
 }
 

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -46,9 +45,6 @@ func (w *walletFilePbkdf2) decrypt(password []byte) (err error) {
 	derivedKey := pbkdf2.Key(password, w.Crypto.KDFParams.Salt, w.Crypto.KDFParams.C, w.Crypto.KDFParams.DKLen, sha256.New)
 
 	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
-	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
-	}
 	return err
 
 }

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -42,9 +42,13 @@ func TestPbkdf2Wallet(t *testing.T) {
 
 	w1 := &walletFilePbkdf2{
 		walletFileBase: walletFileBase{
-			Address: ethtypes.AddressPlainHex(keypair.Address),
-			ID:      fftypes.NewUUID(),
-			Version: version3,
+			walletFileCoreFields: walletFileCoreFields{
+				ID:      fftypes.NewUUID(),
+				Version: version3,
+			},
+			walletFileMetadata: walletFileMetadata{
+				Address: ethtypes.AddressPlainHex(keypair.Address),
+			},
 			keypair: keypair,
 		},
 		Crypto: cryptoPbkdf2{
@@ -78,14 +82,14 @@ func TestPbkdf2Wallet(t *testing.T) {
 
 func TestPbkdf2WalletFileDecryptInvalid(t *testing.T) {
 
-	_, err := readPbkdf2WalletFile([]byte(`!! not json`), []byte(""))
+	_, err := readPbkdf2WalletFile([]byte(`!! not json`), []byte(""), nil)
 	assert.Regexp(t, "invalid pbkdf2 keystore", err)
 
 }
 
 func TestPbkdf2WalletFileUnsupportedPRF(t *testing.T) {
 
-	_, err := readPbkdf2WalletFile([]byte(`{}`), []byte(""))
+	_, err := readPbkdf2WalletFile([]byte(`{}`), []byte(""), nil)
 	assert.Regexp(t, "invalid pbkdf2 wallet file: unsupported prf", err)
 
 }

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -47,9 +47,10 @@ func TestPbkdf2Wallet(t *testing.T) {
 				Version: version3,
 			},
 			walletFileMetadata: walletFileMetadata{
-				Address: ethtypes.AddressPlainHex(keypair.Address),
+				metadata: map[string]interface{}{
+					"address": ethtypes.AddressPlainHex(keypair.Address).String(),
+				},
 			},
-			keypair: keypair,
 		},
 		Crypto: cryptoPbkdf2{
 			cryptoCommon: cryptoCommon{

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -47,14 +47,14 @@ func mustGenerateDerivedScryptKey(password string, salt []byte, n, p int) []byte
 }
 
 // creates an ethereum address wallet file
-func newScryptWalletFile(password string, keypair *secp256k1.KeyPair, n int, p int) WalletFile {
-	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), ethtypes.AddressPlainHex(keypair.Address), n, p)
-	wf.keypair = keypair
+func newScryptWalletFileSecp256k1(password string, keypair *secp256k1.KeyPair, n int, p int) WalletFile {
+	wf := newScryptWalletFileBytes(password, keypair.PrivateKeyBytes(), n, p)
+	wf.Metadata()["address"] = ethtypes.AddressPlainHex(keypair.Address).String()
 	return wf
 }
 
 // this allows creation of any size/type of key in the store
-func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.AddressPlainHex, n int, p int) *walletFileScrypt {
+func newScryptWalletFileBytes(password string, privateKey []byte, n int, p int) *walletFileScrypt {
 
 	// Generate a sale for the scrypt
 	salt := mustReadBytes(32, rand.Reader)
@@ -81,7 +81,6 @@ func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.
 				Version: version3,
 			},
 			walletFileMetadata: walletFileMetadata{
-				Address:  addr,
 				metadata: map[string]interface{}{},
 			},
 			privateKey: privateKey,
@@ -113,8 +112,5 @@ func (w *walletFileScrypt) decrypt(password []byte) error {
 		return fmt.Errorf("invalid scrypt keystore: %s", err)
 	}
 	w.privateKey, err = w.Crypto.decryptCommon(derivedKey)
-	if err == nil {
-		w.keypair, err = secp256k1.NewSecp256k1KeyPair(w.privateKey)
-	}
 	return err
 }

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -29,11 +29,12 @@ import (
 
 const defaultR = 8
 
-func readScryptWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
+func readScryptWalletFile(jsonWallet []byte, password []byte, metadata map[string]interface{}) (WalletFile, error) {
 	var w *walletFileScrypt
 	if err := json.Unmarshal(jsonWallet, &w); err != nil {
 		return nil, fmt.Errorf("invalid scrypt wallet file: %s", err)
 	}
+	w.metadata = metadata
 	return w, w.decrypt(password)
 }
 
@@ -75,9 +76,14 @@ func newScryptWalletFileBytes(password string, privateKey []byte, addr ethtypes.
 
 	return &walletFileScrypt{
 		walletFileBase: walletFileBase{
-			ID:         fftypes.NewUUID(),
-			Address:    addr,
-			Version:    version3,
+			walletFileCoreFields: walletFileCoreFields{
+				ID:      fftypes.NewUUID(),
+				Version: version3,
+			},
+			walletFileMetadata: walletFileMetadata{
+				Address:  addr,
+				metadata: map[string]interface{}{},
+			},
 			privateKey: privateKey,
 		},
 		Crypto: cryptoScrypt{

--- a/pkg/keystorev3/scrypt_test.go
+++ b/pkg/keystorev3/scrypt_test.go
@@ -58,7 +58,7 @@ func TestScryptWalletRoundTripStandard(t *testing.T) {
 
 func TestScryptReadInvalidFile(t *testing.T) {
 
-	_, err := readScryptWalletFile([]byte(`!bad JSON`), []byte(""))
+	_, err := readScryptWalletFile([]byte(`!bad JSON`), []byte(""), nil)
 	assert.Error(t, err)
 
 }

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -58,7 +58,11 @@ func NewWalletFileCustomBytesStandard(password string, privateKey []byte) Wallet
 
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
 	var w walletFileCommon
-	if err := json.Unmarshal(jsonWallet, &w); err != nil {
+	err := json.Unmarshal(jsonWallet, &w)
+	if err == nil {
+		err = json.Unmarshal(jsonWallet, &w.metadata)
+	}
+	if err != nil {
 		return nil, fmt.Errorf("invalid wallet file: %s", err)
 	}
 	if w.ID == nil {
@@ -69,9 +73,9 @@ func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {
 	}
 	switch w.Crypto.KDF {
 	case kdfTypeScrypt:
-		return readScryptWalletFile(jsonWallet, password)
+		return readScryptWalletFile(jsonWallet, password, w.metadata)
 	case kdfTypePbkdf2:
-		return readPbkdf2WalletFile(jsonWallet, password)
+		return readPbkdf2WalletFile(jsonWallet, password, w.metadata)
 	default:
 		return nil, fmt.Errorf("unsupported kdf: %s", w.Crypto.KDF)
 	}

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/secp256k1"
 	"golang.org/x/crypto/sha3"
 )
@@ -33,27 +32,19 @@ const (
 )
 
 func NewWalletFileLight(password string, keypair *secp256k1.KeyPair) WalletFile {
-	return newScryptWalletFile(password, keypair, nLight, pDefault)
+	return newScryptWalletFileSecp256k1(password, keypair, nLight, pDefault)
 }
 
 func NewWalletFileStandard(password string, keypair *secp256k1.KeyPair) WalletFile {
-	return newScryptWalletFile(password, keypair, nStandard, pDefault)
-}
-
-func addressFirst32(privateKey []byte) ethtypes.AddressPlainHex {
-	if len(privateKey) > 32 {
-		privateKey = privateKey[0:32]
-	}
-	kp, _ := secp256k1.NewSecp256k1KeyPair(privateKey)
-	return ethtypes.AddressPlainHex(kp.Address)
+	return newScryptWalletFileSecp256k1(password, keypair, nStandard, pDefault)
 }
 
 func NewWalletFileCustomBytesLight(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
 }
 
 func NewWalletFileCustomBytesStandard(password string, privateKey []byte) WalletFile {
-	return newScryptWalletFileBytes(password, privateKey, addressFirst32(privateKey), nStandard, pDefault)
+	return newScryptWalletFileBytes(password, privateKey, nStandard, pDefault)
 }
 
 func ReadWalletFile(jsonWallet []byte, password []byte) (WalletFile, error) {

--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -92,8 +92,6 @@ type walletFileCoreFields struct {
 }
 
 type walletFileMetadata struct {
-	// address is not technically part of keystorev3 syntax, and note this can be overridden/removed by callers of the package
-	Address ethtypes.AddressPlainHex `json:"address"`
 	// arbitrary additional fields that can be stored in the JSON, including overriding/removing the "address" field (other core fields cannot be overridden)
 	metadata map[string]interface{}
 }
@@ -102,7 +100,6 @@ type walletFileBase struct {
 	walletFileCoreFields
 	walletFileMetadata
 	privateKey []byte
-	keypair    *secp256k1.KeyPair
 }
 
 type walletFileCommon struct {
@@ -146,12 +143,8 @@ func marshalWalletJSON(wc *walletFileBase, crypto interface{}) ([]byte, error) {
 		return nil, err
 	}
 	jsonMap := map[string]interface{}{}
-	// note address can be set to "nil" to remove it entirely
-	jsonMap["address"] = wc.Address
 	for k, v := range wc.metadata {
-		if v == nil {
-			delete(jsonMap, k)
-		} else {
+		if v != nil {
 			jsonMap[k] = v
 		}
 	}
@@ -163,7 +156,7 @@ func marshalWalletJSON(wc *walletFileBase, crypto interface{}) ([]byte, error) {
 }
 
 func (w *walletFileBase) KeyPair() *secp256k1.KeyPair {
-	return w.keypair
+	return secp256k1.KeyPairFromBytes(w.privateKey)
 }
 
 func (w *walletFileBase) PrivateKey() []byte {

--- a/pkg/secp256k1/keypair.go
+++ b/pkg/secp256k1/keypair.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -43,9 +43,15 @@ func GenerateSecp256k1KeyPair() (*KeyPair, error) {
 	return wrapSecp256k1Key(key, key.PubKey()), nil
 }
 
+// Note there is no error condition returned by this function (use KeyPairFromBytes)
 func NewSecp256k1KeyPair(b []byte) (*KeyPair, error) {
 	key, pubKey := btcec.PrivKeyFromBytes(b)
 	return wrapSecp256k1Key(key, pubKey), nil
+}
+
+func KeyPairFromBytes(b []byte) *KeyPair {
+	key, pubKey := btcec.PrivKeyFromBytes(b)
+	return wrapSecp256k1Key(key, pubKey)
 }
 
 func wrapSecp256k1Key(key *btcec.PrivateKey, pubKey *btcec.PublicKey) *KeyPair {


### PR DESCRIPTION
In PR chain with #70 

There are cases where we need to build descriptors of functions/events (and their containing structures) that preserve the full information of how they will be parsed/serialized.

For example when determining if the list of event definitions, including containing type names, is identical to another list.

This PR provides that feature, and does it uses `Solidity` as the inspiration for the formatting, which makes it human readable.

The solidity strings have the characteristic that they uniquely identify each function, including where overrides are used.