### PR TITLE
Add correct permissions for action

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Due to new changes the GitHub Token in the action no longer has the write permissions and thus the actions fail when pushing the docker image to `ghcr.io`.  To enable the GitHub token to have those permissions, it now needs to be specified within the job itself.

403 forbidden error https://github.com/hyperledger/firefly-signer/actions/runs/10359460639

```
The push refers to repository [ghcr.io/hyperledger/firefly-signer]
fecdbc4471ce: Preparing
31d7a001c31a: Preparing
96bc1885c3ff: Preparing
6f697f52d485: Preparing
denied: installation not allowed to Write organization package
```