### PR TITLE
Solsig indexed

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -702,6 +702,7 @@ func (e *Entry) SolidityDef() (string, []string, error) {
 func (e *Entry) SolidityDefCtx(ctx context.Context) (string, []string, error) {
 	// Everything apart from event and error is a type of function
 	isFunction := e.Type != Error && e.Type != Event
+	isEvent := e.Type == Event
 
 	allChildStructs := []string{}
 	buff := new(strings.Builder)
@@ -713,7 +714,7 @@ func (e *Entry) SolidityDefCtx(ctx context.Context) (string, []string, error) {
 		if i > 0 {
 			buff.WriteString(", ")
 		}
-		s, childStructs, err := p.SolidityDefCtx(ctx, isFunction)
+		s, childStructs, err := p.SolidityDefCtx(ctx, isFunction, isEvent)
 		if err != nil {
 			return "", nil, err
 		}
@@ -736,7 +737,7 @@ func (e *Entry) SolidityDefCtx(ctx context.Context) (string, []string, error) {
 				if i > 0 {
 					buff.WriteString(", ")
 				}
-				s, childStructs, err := p.SolidityDefCtx(ctx, isFunction)
+				s, childStructs, err := p.SolidityDefCtx(ctx, true, false)
 				if err != nil {
 					return "", nil, err
 				}
@@ -782,13 +783,13 @@ func (p *Parameter) SignatureStringCtx(ctx context.Context) (string, error) {
 	return tc.String(), nil
 }
 
-func (p *Parameter) SolidityDefCtx(ctx context.Context, inFunction bool) (string, []string, error) {
+func (p *Parameter) SolidityDefCtx(ctx context.Context, isFunction, isEvent bool) (string, []string, error) {
 	// Ensure the type component tree has been parsed
 	tc, err := p.TypeComponentTreeCtx(ctx)
 	if err != nil {
 		return "", nil, err
 	}
-	solDef, childStructs := tc.SolidityParamDef(inFunction)
+	solDef, childStructs := tc.SolidityParamDef(isFunction, isEvent)
 	return solDef, childStructs, nil
 }
 

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -226,6 +226,11 @@ const sampleABI5 = `[
           "internalType": "struct AribtraryWidgets.Widget[]",
           "name": "widgets",
           "type": "tuple[]"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true
         }
       ],
       "name": "Invoiced",
@@ -1015,7 +1020,7 @@ func TestComplexStructSolidityDef(t *testing.T) {
 
 	solDef, childStructs, err = abi.Events()["Invoiced"].SolidityDef()
 	assert.NoError(t, err)
-	assert.Equal(t, "event Invoiced(Customer customer, Widget[] widgets)", solDef)
+	assert.Equal(t, "event Invoiced(Customer customer, Widget[] widgets, address indexed account)", solDef)
 	assert.Equal(t, []string{
 		"struct Customer { address owner; bytes32 locator; }",
 		"struct Widget { string description; uint256 price; string[] attributes; }",

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -66,7 +66,7 @@ type TypeComponent interface {
 	DecodeABIData(d []byte, offset int) (*ComponentValue, error)
 	DecodeABIDataCtx(ctx context.Context, d []byte, offest int) (*ComponentValue, error)
 
-	SolidityParamDef(inFunction bool) (solDef string, structDefs []string) // gives a string that can be used to define this param in solidity
+	SolidityParamDef(isFunction, isEvent bool) (solDef string, structDefs []string) // gives a string that can be used to define this param in solidity
 	SolidityTypeDef() (isRef bool, typeDef string, childStructs []string)
 	SolidityStructDef() (structName string, structs []string)
 }
@@ -371,13 +371,18 @@ func (tc *typeComponent) String() string {
 	}
 }
 
-func (tc *typeComponent) SolidityParamDef(inFunction bool) (string, []string) {
+func (tc *typeComponent) SolidityParamDef(isFunction, isEvent bool) (string, []string) {
 	isRef, paramDef, childStructs := tc.SolidityTypeDef()
-	if isRef && inFunction {
-		paramDef = fmt.Sprintf("%s memory", paramDef)
+	if isRef && isFunction {
+		paramDef += " memory"
 	}
-	if tc.parameter != nil && tc.parameter.Name != "" {
-		paramDef = fmt.Sprintf("%s %s", paramDef, tc.parameter.Name)
+	if tc.parameter != nil {
+		if isEvent && tc.parameter.Indexed {
+			paramDef += " indexed"
+		}
+		if tc.parameter.Name != "" {
+			paramDef = fmt.Sprintf("%s %s", paramDef, tc.parameter.Name)
+		}
 	}
 	return paramDef, childStructs
 }

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -19,6 +19,7 @@ package rpcbackend
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -91,7 +92,7 @@ type RPCError struct {
 }
 
 func (e *RPCError) Error() error {
-	return fmt.Errorf(e.Message)
+	return errors.New(e.Message)
 }
 
 func (e *RPCError) String() string {
@@ -208,7 +209,7 @@ func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRe
 			rpcMsg = i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, res.Status()).Error()
 		}
 		log.L(ctx).Errorf("RPC[%s] <-- [%d]: %s", rpcTraceID, res.StatusCode(), errLog)
-		err := fmt.Errorf(rpcMsg)
+		err := errors.New(rpcMsg)
 		return rpcRes, err
 	}
 	log.L(ctx).Infof("RPC[%s] <-- %s [%d] OK (%.2fms)", rpcTraceID, rpcReq.Method, res.StatusCode(), float64(time.Since(rpcStartTime))/float64(time.Millisecond))


### PR DESCRIPTION
After all the work in #71, I ended up missing one of the most important distinguishing things the feature was meant to help with 🤦 

The ABI signature of an event is identical for ERC-20/ERC-721, but some of the fields are indexed. I'd missed including that.

In PR chain with #73 