### PR TITLE
Add support for 256 bit JSON numbers (vs. strings), including scientific notation

### DIFF
--- a/config.md
+++ b/config.md
@@ -56,15 +56,25 @@ nav_order: 2
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
 |maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 
+## backend.throttle
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|burst|The maximum number of requests that can be made in a short period of time before the throttling kicks in.|`int`|`<nil>`
+|requestsPerSecond|The average rate at which requests are allowed to pass through over time.|`int`|`<nil>`
+
 ## backend.tls
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
+|ca|The TLS certificate authority in PEM format (this option is ignored if caFile is also set)|`string`|`<nil>`
 |caFile|The path to the CA file for TLS on this API|`string`|`<nil>`
+|cert|The TLS certificate in PEM format (this option is ignored if certFile is also set)|`string`|`<nil>`
 |certFile|The path to the certificate file for TLS on this API|`string`|`<nil>`
 |clientAuth|Enables or disables client auth for TLS on this API|`string`|`<nil>`
 |enabled|Enables or disables TLS on this API|`boolean`|`false`
 |insecureSkipHostVerify|When to true in unit test development environments to disable TLS verification. Use with extreme caution|`boolean`|`<nil>`
+|key|The TLS certificate key in PEM format (this option is ignored if keyFile is also set)|`string`|`<nil>`
 |keyFile|The path to the private key file for TLS on this API|`string`|`<nil>`
 |requiredDNAttributes|A set of required subject DN attributes. Each entry is a regular expression, and the subject certificate must have a matching attribute of the specified type (CN, C, O, OU, ST, L, STREET, POSTALCODE, SERIALNUMBER are valid attributes)|`map[string]string`|`<nil>`
 
@@ -181,10 +191,13 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
+|ca|The TLS certificate authority in PEM format (this option is ignored if caFile is also set)|`string`|`<nil>`
 |caFile|The path to the CA file for TLS on this API|`string`|`<nil>`
+|cert|The TLS certificate in PEM format (this option is ignored if certFile is also set)|`string`|`<nil>`
 |certFile|The path to the certificate file for TLS on this API|`string`|`<nil>`
 |clientAuth|Enables or disables client auth for TLS on this API|`string`|`<nil>`
 |enabled|Enables or disables TLS on this API|`boolean`|`false`
 |insecureSkipHostVerify|When to true in unit test development environments to disable TLS verification. Use with extreme caution|`boolean`|`<nil>`
+|key|The TLS certificate key in PEM format (this option is ignored if keyFile is also set)|`string`|`<nil>`
 |keyFile|The path to the private key file for TLS on this API|`string`|`<nil>`
 |requiredDNAttributes|A set of required subject DN attributes. Each entry is a regular expression, and the subject certificate must have a matching attribute of the specified type (CN, C, O, OU, ST, L, STREET, POSTALCODE, SERIALNUMBER are valid attributes)|`map[string]string`|`<nil>`

--- a/go.mod
+++ b/go.mod
@@ -71,8 +71,11 @@ require (
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/hyperledger/firefly-common => github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hyperledger/firefly-common v1.4.6 h1:qqXoSaRml3WjUnWcWxrrXs5AIOWa+UcMXLCF8yEa4Pk=
-github.com/hyperledger/firefly-common v1.4.6/go.mod h1:jkErZdQmC9fsAJZQO427tURdwB9iiW+NMUZSqS3eBIE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=
@@ -56,6 +54,8 @@ github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bww
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156 h1:HQpScPoAm9xsACbu9r31wVQ5sQFxLsfe9XzPGY5c4rI=
+github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
 github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/karlseguin/expect v1.0.8 h1:Bb0H6IgBWQpadY25UDNkYPDB9ITqK1xnSoZfAq362fw=

--- a/pkg/abi/inputparsing.go
+++ b/pkg/abi/inputparsing.go
@@ -135,17 +135,7 @@ func getIntegerFromInterface(ctx context.Context, desc string, v interface{}) (*
 		// no prefix means decimal etc.
 		i, ok := i.SetString(vt, 0)
 		if !ok {
-			f, _, err := big.ParseFloat(vt, 10, 256, big.ToNearestEven)
-			if err != nil {
-				return nil, i18n.NewError(ctx, signermsgs.MsgInvalidIntegerABIInput, vt, v, desc)
-			}
-			i, accuracy := f.Int(i)
-			if accuracy != big.Exact {
-				// If we weren't able to decode without losing precision, return an error
-				return nil, i18n.NewError(ctx, signermsgs.MsgInvalidIntegerABIInput, vt, v, desc)
-			}
-
-			return i, nil
+			return nil, i18n.NewError(ctx, signermsgs.MsgInvalidIntegerABIInput, vt, v, desc)
 		}
 		return i, nil
 	case *big.Float:

--- a/pkg/abi/inputparsing_test.go
+++ b/pkg/abi/inputparsing_test.go
@@ -18,9 +18,11 @@ package abi
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/stretchr/testify/assert"
 )
@@ -185,6 +187,30 @@ func TestGetIntegerFromInterface(t *testing.T) {
 	i, err = getIntegerFromInterface(ctx, "ut", &iI32)
 	assert.NoError(t, err)
 	assert.Equal(t, "-12345", i.String())
+
+	var scientificNumber fftypes.JSONAny
+	err = json.Unmarshal([]byte("1.0000000000000000000000001e+25"), &scientificNumber)
+	assert.NoError(t, err)
+
+	i, err = getIntegerFromInterface(ctx, "ut", scientificNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, "10000000000000000000000001", i.String())
+
+	var hugeNumber fftypes.JSONAny
+	err = json.Unmarshal([]byte("10000000000000000000000000000001"), &hugeNumber)
+	assert.NoError(t, err)
+
+	i, err = getIntegerFromInterface(ctx, "ut", hugeNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, "10000000000000000000000000000001", i.String())
+
+	var jsonNumber json.Number
+	err = json.Unmarshal([]byte("20000000000000000000000000000002"), &jsonNumber)
+	assert.NoError(t, err)
+
+	i, err = getIntegerFromInterface(ctx, "ut", jsonNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, "20000000000000000000000000000002", i.String())
 
 	i32 := int32(-12345)
 	var iPI32 TestInt32PtrCustomType = &i32

--- a/pkg/abi/inputparsing_test.go
+++ b/pkg/abi/inputparsing_test.go
@@ -18,11 +18,9 @@ package abi
 
 import (
 	"context"
-	"encoding/json"
 	"math/big"
 	"testing"
 
-	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/stretchr/testify/assert"
 )
@@ -187,22 +185,6 @@ func TestGetIntegerFromInterface(t *testing.T) {
 	i, err = getIntegerFromInterface(ctx, "ut", &iI32)
 	assert.NoError(t, err)
 	assert.Equal(t, "-12345", i.String())
-
-	var scientificNumber fftypes.JSONAny
-	err = json.Unmarshal([]byte("1.0000000000000000000000001e+25"), &scientificNumber)
-	assert.NoError(t, err)
-
-	i, err = getIntegerFromInterface(ctx, "ut", scientificNumber)
-	assert.NoError(t, err)
-	assert.Equal(t, "10000000000000000000000001", i.String())
-
-	var hugeNumber fftypes.JSONAny
-	err = json.Unmarshal([]byte("10000000000000000000000000000001"), &hugeNumber)
-	assert.NoError(t, err)
-
-	i, err = getIntegerFromInterface(ctx, "ut", hugeNumber)
-	assert.NoError(t, err)
-	assert.Equal(t, "10000000000000000000000000000001", i.String())
 
 	i32 := int32(-12345)
 	var iPI32 TestInt32PtrCustomType = &i32

--- a/pkg/abi/inputparsing_test.go
+++ b/pkg/abi/inputparsing_test.go
@@ -18,9 +18,11 @@ package abi
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/stretchr/testify/assert"
 )
@@ -185,6 +187,22 @@ func TestGetIntegerFromInterface(t *testing.T) {
 	i, err = getIntegerFromInterface(ctx, "ut", &iI32)
 	assert.NoError(t, err)
 	assert.Equal(t, "-12345", i.String())
+
+	var scientificNumber fftypes.JSONAny
+	err = json.Unmarshal([]byte("1.0000000000000000000000001e+25"), &scientificNumber)
+	assert.NoError(t, err)
+
+	i, err = getIntegerFromInterface(ctx, "ut", scientificNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, "10000000000000000000000001", i.String())
+
+	var hugeNumber fftypes.JSONAny
+	err = json.Unmarshal([]byte("10000000000000000000000000000001"), &hugeNumber)
+	assert.NoError(t, err)
+
+	i, err = getIntegerFromInterface(ctx, "ut", hugeNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, "10000000000000000000000000000001", i.String())
 
 	i32 := int32(-12345)
 	var iPI32 TestInt32PtrCustomType = &i32


### PR DESCRIPTION
This PR relates to `firefly-common` PR https://github.com/hyperledger/firefly-common/pull/147

That PR introduces support for large JSON numbers where previously they would be limited to the size of `float64` `2^64-1`. This is particularly useful when dealing with the scale of numeric parameters typical of Ethereum smart contracts. See PR https://github.com/hyperledger/firefly-common/pull/147 for more information.

This `firefly-signer` PR does 2 things:

1. Pulls in the latest version of `firefly-common` to utilize the new large number support
2. Adds a fallback approach to parsing strings to handle scientific notation numbers e.g. `1e+25`.