### PR TITLE
Add utility for parsing errors, including as a string

### DIFF
--- a/pkg/abi/signedi256.go
+++ b/pkg/abi/signedi256.go
@@ -26,9 +26,9 @@ var posMax = map[uint16]*big.Int{}
 var negMax = map[uint16]*big.Int{}
 
 func init() {
-	for i := 8; i <= 256; i += 8 {
-		posMax[uint16(i)] = maxPositiveSignedInt(uint(i))
-		negMax[uint16(i)] = maxNegativeSignedInt(uint(i))
+	for i := uint16(8); i <= uint16(256); i += 8 {
+		posMax[i] = maxPositiveSignedInt(uint(i))
+		negMax[i] = maxNegativeSignedInt(uint(i))
 	}
 }
 

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -630,6 +630,7 @@ func parseMSuffix(ctx context.Context, abiTypeString string, ec *typeComponent, 
 	if err != nil {
 		return i18n.WrapError(ctx, err, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
 	}
+	//nolint:gosec // we used bitSize on ParseUint above
 	ec.m = uint16(val)
 	if ec.m < ec.elementaryType.mMin || ec.m > ec.elementaryType.mMax {
 		return i18n.NewError(ctx, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
@@ -646,6 +647,7 @@ func parseNSuffix(ctx context.Context, abiTypeString string, ec *typeComponent, 
 	if err != nil {
 		return i18n.WrapError(ctx, err, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
 	}
+	//nolint:gosec // we used bitSize on ParseUint above
 	ec.n = uint16(val)
 	if ec.n < ec.elementaryType.nMin || ec.n > ec.elementaryType.nMax {
 		return i18n.NewError(ctx, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
@@ -672,10 +674,11 @@ func parseMxNSuffix(ctx context.Context, abiTypeString string, ec *typeComponent
 
 // parseArrayM parses the "8" in "uint256[8]" for a fixed length array of <type>[M]
 func parseArrayM(ctx context.Context, abiTypeString string, ac *typeComponent, mStr string) error {
-	val, err := strconv.ParseUint(mStr, 10, 64)
+	val, err := strconv.ParseUint(mStr, 10, 32)
 	if err != nil {
 		return i18n.WrapError(ctx, err, signermsgs.MsgInvalidABIArraySpec, abiTypeString)
 	}
+	//nolint:gosec // we used bitSize on ParseUint above
 	ac.arrayLength = int(val)
 	return nil
 }


### PR DESCRIPTION
A helpful utility for custom errors, to let you send `revertData` to the function, and get back a string like:

`ExampleError("test1","12345")`

or for default `revert("some string")`

`Error("some string")`