### PR TITLE
Handle unnamed tuple entries consistently on input and output

### DIFF
--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -56,7 +56,6 @@ var (
 	MsgFixedLengthABIArrayMismatch = ffe("FF22036", "Input array is length %d, and required fixed array length is %d for component %s")
 	MsgTupleABIArrayMismatch       = ffe("FF22037", "Input array is length %d, and required tuple component count is %d for component %s")
 	MsgTupleABINotArrayOrMap       = ffe("FF22038", "Input type %T is not array or map for component %s")
-	MsgTupleInABINoName            = ffe("FF22039", "Tuple child %d does not have a name for component %s")
 	MsgMissingInputKeyABITuple     = ffe("FF22040", "Input map missing key '%s' required for tuple component %s")
 	MsgBadABITypeComponent         = ffe("FF22041", "Bad ABI type component: %d")
 	MsgWrongTypeComponentABIEncode = ffe("FF22042", "Incorrect type expected=%s found=%T for ABI encoding of component %s")

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const sampleABI1 = `[
@@ -1070,5 +1071,28 @@ func TestErrorString(t *testing.T) {
 	mismatchError := ethtypes.MustNewHexBytes0xPrefix(`0x11223344`)
 	_, ok = customErrABI.ErrorString(mismatchError)
 	assert.False(t, ok)
+
+}
+
+func TestUnnamedInputOutput(t *testing.T) {
+
+	sampleABI := ABI{
+		{Type: Function, Name: "set", Inputs: ParameterArray{
+			{Type: "uint256"},
+			{Type: "string"},
+		}},
+	}
+
+	cv, err := sampleABI[0].Inputs.ParseJSON([]byte(`{"0":12345,"1":"test"}`))
+	require.NoError(t, err)
+	res, err := NewSerializer().SetFormattingMode(FormatAsFlatArrays).SerializeJSON(cv)
+	require.NoError(t, err)
+	require.JSONEq(t, `["12345","test"]`, string(res))
+
+	cv, err = sampleABI[0].Inputs.ParseJSON([]byte(`[12345,"test"]`))
+	require.NoError(t, err)
+	res, err = NewSerializer().SetFormattingMode(FormatAsObjects).SerializeJSON(cv)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"0":"12345","1":"test"}`, string(res))
 
 }

--- a/pkg/abi/inputparsing.go
+++ b/pkg/abi/inputparsing.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
@@ -456,13 +457,14 @@ func walkTupleInput(ctx context.Context, breadcrumbs string, input interface{}, 
 		Children:  make([]*ComponentValue, len(component.tupleChildren)),
 	}
 	for i, tupleChild := range component.tupleChildren {
-		if tupleChild.keyName == "" {
-			return nil, i18n.NewError(ctx, signermsgs.MsgTupleInABINoName, i, breadcrumbs)
+		keyName := tupleChild.keyName
+		if keyName == "" {
+			keyName = strconv.Itoa(i)
 		}
-		childBreadcrumbs := fmt.Sprintf("%s.%s", breadcrumbs, tupleChild.keyName)
-		v, ok := iMap[tupleChild.keyName]
+		childBreadcrumbs := fmt.Sprintf("%s.%s", breadcrumbs, keyName)
+		v, ok := iMap[keyName]
 		if !ok {
-			return nil, i18n.NewError(ctx, signermsgs.MsgMissingInputKeyABITuple, tupleChild.keyName, childBreadcrumbs)
+			return nil, i18n.NewError(ctx, signermsgs.MsgMissingInputKeyABITuple, keyName, childBreadcrumbs)
 		}
 		cv.Children[i], err = walkInput(ctx, childBreadcrumbs, v, component.tupleChildren[i])
 		if err != nil {

--- a/pkg/abi/inputparsing_test.go
+++ b/pkg/abi/inputparsing_test.go
@@ -230,6 +230,10 @@ func TestGetIntegerFromInterface(t *testing.T) {
 	assert.Regexp(t, "FF22030", err)
 	assert.Nil(t, i)
 
+	i, err = getIntegerFromInterface(ctx, "ut", json.Number("wrong"))
+	assert.Regexp(t, "FF22030", err)
+	assert.Nil(t, i)
+
 }
 
 func TestGetFloatFromInterface(t *testing.T) {
@@ -666,39 +670,6 @@ func TestTuplesWrongType(t *testing.T) {
 	_, err := inputs.ParseJSON([]byte(values))
 	assert.Regexp(t, "FF22038", err)
 
-}
-
-func TestTuplesMissingName(t *testing.T) {
-	const sample = `[
-		{
-		"name": "foo",
-		"type": "function",
-		"inputs": [
-			{
-				"name": "a",
-				"type": "tuple",
-				"components": [
-					{
-						"type": "uint256"
-					}
-				]
-			}
-		],
-		"outputs": []
-		}
-	]`
-
-	inputs := testABI(t, sample)[0].Inputs
-
-	// Fine if you use the array syntax
-	values := `{ "a": [12345] }`
-	_, err := inputs.ParseJSON([]byte(values))
-	assert.NoError(t, err)
-
-	// But the missing name is a problem for the object syntax
-	values = `{ "a": {"b":12345} }`
-	_, err = inputs.ParseJSON([]byte(values))
-	assert.Regexp(t, "FF22039", err)
 }
 
 func TestTupleEncodeIndividualFixedParam(t *testing.T) {

--- a/pkg/abi/signedi256.go
+++ b/pkg/abi/signedi256.go
@@ -26,9 +26,9 @@ var posMax = map[uint16]*big.Int{}
 var negMax = map[uint16]*big.Int{}
 
 func init() {
-	for i := 8; i <= 256; i += 8 {
-		posMax[uint16(i)] = maxPositiveSignedInt(uint(i))
-		negMax[uint16(i)] = maxNegativeSignedInt(uint(i))
+	for i := uint16(8); i <= uint16(256); i += 8 {
+		posMax[i] = maxPositiveSignedInt(uint(i))
+		negMax[i] = maxNegativeSignedInt(uint(i))
 	}
 }
 

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -630,6 +630,7 @@ func parseMSuffix(ctx context.Context, abiTypeString string, ec *typeComponent, 
 	if err != nil {
 		return i18n.WrapError(ctx, err, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
 	}
+	//nolint:gosec // we used bitSize on ParseUint above
 	ec.m = uint16(val)
 	if ec.m < ec.elementaryType.mMin || ec.m > ec.elementaryType.mMax {
 		return i18n.NewError(ctx, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
@@ -646,6 +647,7 @@ func parseNSuffix(ctx context.Context, abiTypeString string, ec *typeComponent, 
 	if err != nil {
 		return i18n.WrapError(ctx, err, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
 	}
+	//nolint:gosec // we used bitSize on ParseUint above
 	ec.n = uint16(val)
 	if ec.n < ec.elementaryType.nMin || ec.n > ec.elementaryType.nMax {
 		return i18n.NewError(ctx, signermsgs.MsgInvalidABISuffix, abiTypeString, ec.elementaryType)
@@ -672,10 +674,11 @@ func parseMxNSuffix(ctx context.Context, abiTypeString string, ec *typeComponent
 
 // parseArrayM parses the "8" in "uint256[8]" for a fixed length array of <type>[M]
 func parseArrayM(ctx context.Context, abiTypeString string, ac *typeComponent, mStr string) error {
-	val, err := strconv.ParseUint(mStr, 10, 64)
+	val, err := strconv.ParseUint(mStr, 10, 32)
 	if err != nil {
 		return i18n.WrapError(ctx, err, signermsgs.MsgInvalidABIArraySpec, abiTypeString)
 	}
+	//nolint:gosec // we used bitSize on ParseUint above
 	ac.arrayLength = int(val)
 	return nil
 }


### PR DESCRIPTION
In PR chain with #82 

We were throwing an error in the case that you supplied an input like `{"0":12345}` to an ABI with an unnamed parameter, but on output we were perfectly accepting that values could have unnamed parameters and we did translation to `0` in the object syntax.

This PR makes us consistent in both directions.

It's a change in behavior, but only from returning an error, to having a defined behavior.