### PR TITLE
Fix negative integer hex formatting and add JSON number formatting option

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -394,7 +394,9 @@ func (pa ParameterArray) ParseJSON(data []byte) (*ComponentValue, error) {
 
 func (pa ParameterArray) ParseJSONCtx(ctx context.Context, data []byte) (*ComponentValue, error) {
 	var jsonTree interface{}
-	err := json.Unmarshal(data, &jsonTree)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	err := decoder.Decode(&jsonTree)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -685,7 +685,7 @@ func TestParseJSONArrayLotsOfTypes(t *testing.T) {
 func TestParseJSONBadData(t *testing.T) {
 	inputs := testABI(t, sampleABI1)[0].Inputs
 	_, err := inputs.ParseJSON([]byte(`{`))
-	assert.Regexp(t, "unexpected end", err)
+	assert.Regexp(t, "unexpected EOF", err)
 
 }
 

--- a/pkg/abi/outputserialization.go
+++ b/pkg/abi/outputserialization.go
@@ -18,6 +18,7 @@ package abi
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -149,6 +150,10 @@ func HexByteSerializer(b []byte) interface{} {
 
 func HexByteSerializer0xPrefix(b []byte) interface{} {
 	return "0x" + hex.EncodeToString(b)
+}
+
+func Base64ByteSerializer(b []byte) interface{} {
+	return base64.StdEncoding.EncodeToString(b)
 }
 
 func NumericDefaultNameGenerator(idx int) string {

--- a/pkg/abi/outputserialization.go
+++ b/pkg/abi/outputserialization.go
@@ -110,7 +110,16 @@ func Base10StringIntSerializer(i *big.Int) interface{} {
 }
 
 func HexIntSerializer0xPrefix(i *big.Int) interface{} {
-	return "0x" + i.Text(16)
+	absHi := new(big.Int).Abs(i)
+	sign := ""
+	if i.Sign() < 0 {
+		sign = "-"
+	}
+	return fmt.Sprintf("%s0x%s", sign, absHi.Text(16))
+}
+
+func JSONNumberIntSerializer(i *big.Int) interface{} {
+	return json.Number(i.String())
 }
 
 func Base10StringFloatSerializer(f *big.Float) interface{} {

--- a/pkg/abi/outputserialization.go
+++ b/pkg/abi/outputserialization.go
@@ -32,11 +32,12 @@ import (
 // Serializer contains a set of options for how to serialize an parsed
 // ABI value tree, into JSON.
 type Serializer struct {
-	ts FormattingMode
-	is IntSerializer
-	fs FloatSerializer
-	bs ByteSerializer
-	dn DefaultNameGenerator
+	ts     FormattingMode
+	is     IntSerializer
+	fs     FloatSerializer
+	bs     ByteSerializer
+	dn     DefaultNameGenerator
+	pretty bool
 }
 
 // NewSerializer creates a new ABI value tree serializer, with the default
@@ -103,6 +104,11 @@ func (s *Serializer) SetByteSerializer(bs ByteSerializer) *Serializer {
 
 func (s *Serializer) SetDefaultNameGenerator(dn DefaultNameGenerator) *Serializer {
 	s.dn = dn
+	return s
+}
+
+func (s *Serializer) SetPretty(pretty bool) *Serializer {
+	s.pretty = pretty
 	return s
 }
 
@@ -176,6 +182,9 @@ func (s *Serializer) SerializeJSONCtx(ctx context.Context, cv *ComponentValue) (
 	v, err := s.walkOutput(ctx, "", cv)
 	if err != nil {
 		return nil, err
+	}
+	if s.pretty {
+		return json.MarshalIndent(&v, "", "  ")
 	}
 	return json.Marshal(&v)
 }

--- a/pkg/abi/outputserialization_test.go
+++ b/pkg/abi/outputserialization_test.go
@@ -59,6 +59,7 @@ func TestJSONSerializationFormatsTuple(t *testing.T) {
 		SetFormattingMode(FormatAsFlatArrays).
 		SetIntSerializer(HexIntSerializer0xPrefix).
 		SetByteSerializer(HexByteSerializer0xPrefix).
+		SetPretty(true).
 		SerializeJSON(v)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `[
@@ -71,6 +72,7 @@ func TestJSONSerializationFormatsTuple(t *testing.T) {
 			"0xfeedbeef"
 		]
 	]`, string(j2))
+	assert.Contains(t, string(j2), "\n")
 
 	j3, err := NewSerializer().
 		SetFormattingMode(FormatAsSelfDescribingArrays).

--- a/pkg/abi/outputserialization_test.go
+++ b/pkg/abi/outputserialization_test.go
@@ -111,6 +111,40 @@ func TestJSONSerializationFormatsTuple(t *testing.T) {
 	]`, string(j3))
 }
 
+func TestJSONSerializationNumbers(t *testing.T) {
+
+	abi := testABI(t, sampleABI1)
+	assert.NotNil(t, abi)
+
+	v, err := (ParameterArray{{Type: "uint"}, {Type: "int"}}).ParseJSON([]byte(`[
+	   "123000000000000000000000112233",
+	   "-0x18d6f3720c92d9d437801b669"
+	]`))
+	assert.NoError(t, err)
+
+	j, err := v.JSON()
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+	   "0": "123000000000000000000000112233",
+	   "1": "-123000000000000000000000112233"
+	}`, string(j))
+
+	j, err = NewSerializer().SetIntSerializer(HexIntSerializer0xPrefix).SerializeJSON(v)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+	   "0": "0x18d6f3720c92d9d437801b669",
+	   "1": "-0x18d6f3720c92d9d437801b669"
+	}`, string(j))
+
+	j, err = NewSerializer().SetIntSerializer(JSONNumberIntSerializer).SerializeJSON(v)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+	   "0": 123000000000000000000000112233,
+	   "1": -123000000000000000000000112233
+	}`, string(j))
+
+}
+
 func TestJSONSerializationForTypes(t *testing.T) {
 
 	abi := testABI(t, sampleABI2)

--- a/pkg/abi/outputserialization_test.go
+++ b/pkg/abi/outputserialization_test.go
@@ -112,9 +112,6 @@ func TestJSONSerializationFormatsTuple(t *testing.T) {
 
 func TestJSONSerializationNumbers(t *testing.T) {
 
-	abi := testABI(t, sampleABI1)
-	assert.NotNil(t, abi)
-
 	v, err := (ParameterArray{{Type: "uint"}, {Type: "int"}}).ParseJSON([]byte(`[
 	   "123000000000000000000000112233",
 	   "-0x18d6f3720c92d9d437801b669"
@@ -140,6 +137,56 @@ func TestJSONSerializationNumbers(t *testing.T) {
 	assert.JSONEq(t, `{
 	   "0": 123000000000000000000000112233,
 	   "1": -123000000000000000000000112233
+	}`, string(j))
+
+}
+
+func TestJSONSerializationAddresses(t *testing.T) {
+
+	v, err := (ParameterArray{{Type: "address"}}).ParseJSON([]byte(`[
+	   "0xC66A547171fdE5FbEfC546B58E66AaC300Cb6150"
+	]`))
+	assert.NoError(t, err)
+
+	j, err := v.JSON()
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+	   "0": "c66a547171fde5fbefc546b58e66aac300cb6150"
+	}`, string(j))
+
+	j, err = NewSerializer().
+		SetByteSerializer(Base64ByteSerializer). // confirming no effect
+		SerializeJSON(v)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"0": "xmpUcXH95fvvxUa1jmaqwwDLYVA="
+	}`, string(j))
+
+	j, err = NewSerializer().
+		SetByteSerializer(Base64ByteSerializer). // confirming no effect
+		SetAddressSerializer(HexAddrSerializer0xPrefix).
+		SerializeJSON(v)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"0": "0xc66a547171fde5fbefc546b58e66aac300cb6150"
+	 }`, string(j))
+
+	j, err = NewSerializer().
+		SetByteSerializer(Base64ByteSerializer). // confirming no effect
+		SetAddressSerializer(HexAddrSerializerPlain).
+		SerializeJSON(v)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"0": "c66a547171fde5fbefc546b58e66aac300cb6150"
+	}`, string(j))
+
+	j, err = NewSerializer().
+		SetByteSerializer(Base64ByteSerializer). // confirming no effect
+		SetAddressSerializer(ChecksumAddrSerializer).
+		SerializeJSON(v)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"0": "0xC66A547171fdE5FbEfC546B58E66AaC300Cb6150"
 	}`, string(j))
 
 }

--- a/pkg/abi/outputserialization_test.go
+++ b/pkg/abi/outputserialization_test.go
@@ -18,7 +18,6 @@ package abi
 
 import (
 	"context"
-	"encoding/base64"
 	"math/big"
 	"strconv"
 	"testing"
@@ -78,9 +77,7 @@ func TestJSONSerializationFormatsTuple(t *testing.T) {
 		SetIntSerializer(func(i *big.Int) interface{} {
 			return "0o" + i.Text(8)
 		}).
-		SetByteSerializer(func(b []byte) interface{} {
-			return base64.StdEncoding.EncodeToString(b)
-		}).
+		SetByteSerializer(Base64ByteSerializer).
 		SerializeJSON(v)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `[


### PR DESCRIPTION
Note this does not do anything with `fixed` and `ufixed` types, which are really a theoretical thing as they aren't supported by solidity yet (/ever).

When we go back to these, we need to change the internal storage to `big.Int` rather than `big.Float` as otherwise there's a risk of loss of precision.