### PR TITLE
Provide synchronous init option for FS wallet

### DIFF
--- a/config.md
+++ b/config.md
@@ -54,6 +54,7 @@ nav_order: 2
 |count|The maximum number of times to retry|`int`|`5`
 |enabled|Enables retries|`boolean`|`false`
 |errorStatusCodeRegex|The regex that the error response status code must match to trigger retry|`string`|`<nil>`
+|factor|The retry backoff factor|`float32`|`2`
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
 |maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 
@@ -83,6 +84,7 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
+|backgroundConnect|When true the connection is established in the background with infinite reconnect (makes initialConnectAttempts redundant when set)|`boolean`|`false`
 |connectionTimeout|The amount of time to wait while establishing a connection (or auto-reconnection)|[`time.Duration`](https://pkg.go.dev/time#Duration)|`45s`
 |heartbeatInterval|The amount of time to wait between heartbeat signals on the WebSocket connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |initialConnectAttempts|The number of attempts FireFly will make to connect to the WebSocket when starting up, before failing|`int`|`5`

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/gorilla/mux v1.8.1
-	github.com/hyperledger/firefly-common v1.5.1
+	github.com/hyperledger/firefly-common v1.5.5
 	github.com/karlseguin/ccache v2.0.3+incompatible
 	github.com/pelletier/go-toml v1.9.5
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hyperledger/firefly-common v1.5.1 h1:/DREi1ye1HfYr3GDLBhXuugeMzT4zg9EN2uTYFlVY6M=
-github.com/hyperledger/firefly-common v1.5.1/go.mod h1:1Xawm5PUhxT7k+CL/Kr3i1LE3cTTzoQwZMLimvlW8rs=
+github.com/hyperledger/firefly-common v1.5.5 h1:UaANgBIT0aBvAk0Yt+Qrn6qXxpwNIrFfwnW3EBivrQs=
+github.com/hyperledger/firefly-common v1.5.5/go.mod h1:1Xawm5PUhxT7k+CL/Kr3i1LE3cTTzoQwZMLimvlW8rs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=

--- a/pkg/fswallet/fslistener.go
+++ b/pkg/fswallet/fslistener.go
@@ -60,7 +60,7 @@ func (w *fsWallet) fsListenerLoop(ctx context.Context, done func(), events chan 
 				log.L(ctx).Tracef("FSEvent [%s]: %s", event.Op, event.Name)
 				fi, err := os.Stat(event.Name)
 				if err == nil {
-					w.notifyNewFiles(ctx, fi)
+					_ = w.notifyNewFiles(ctx, fi)
 				}
 			}
 		case err, ok := <-errors:

--- a/pkg/fswallet/fslistener_test.go
+++ b/pkg/fswallet/fslistener_test.go
@@ -19,7 +19,6 @@ package fswallet
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -65,16 +64,16 @@ func TestFileListener(t *testing.T) {
 	listener2 := make(chan ethtypes.Address0xHex, 1)
 	f.AddListener(listener2)
 
-	testPWFIle, err := ioutil.ReadFile("../../test/keystore_toml/1f185718734552d08278aa70f804580bab5fd2b4.pwd")
+	testPWFIle, err := os.ReadFile("../../test/keystore_toml/1f185718734552d08278aa70f804580bab5fd2b4.pwd")
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(path.Join(f.conf.Path, "1f185718734552d08278aa70f804580bab5fd2b4.pwd"), testPWFIle, 0644)
+	err = os.WriteFile(path.Join(f.conf.Path, "1f185718734552d08278aa70f804580bab5fd2b4.pwd"), testPWFIle, 0644)
 	assert.NoError(t, err)
 
-	testKeyFIle, err := ioutil.ReadFile("../../test/keystore_toml/1f185718734552d08278aa70f804580bab5fd2b4.key.json")
+	testKeyFIle, err := os.ReadFile("../../test/keystore_toml/1f185718734552d08278aa70f804580bab5fd2b4.key.json")
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(path.Join(f.conf.Path, "1f185718734552d08278aa70f804580bab5fd2b4.key.json"), testKeyFIle, 0644)
+	err = os.WriteFile(path.Join(f.conf.Path, "1f185718734552d08278aa70f804580bab5fd2b4.key.json"), testKeyFIle, 0644)
 	assert.NoError(t, err)
 
 	newAddr1 := <-listener1

--- a/pkg/fswallet/fswallet.go
+++ b/pkg/fswallet/fswallet.go
@@ -247,7 +247,7 @@ func (w *fsWallet) processNewFiles(ctx context.Context, files ...fs.FileInfo) (l
 
 func (w *fsWallet) notifyNewFiles(ctx context.Context, files ...fs.FileInfo) error {
 
-	// This function takes te lock and releases with a copy of the listeners, and a list of new addresses
+	// This function takes the lock and releases with a copy of the listeners, and a list of new addresses
 	listeners, newAddresses := w.processNewFiles(ctx, files...)
 
 	if len(newAddresses) > 0 {


### PR DESCRIPTION
Currently there's an async notification system for keys, which pushes to a channel during initialization or refresh.

I have cases where I want to use this module in a way that is deterministic about knowing if a key does/doesn't exist - and that means I cannot complete initialization (and start up my server) until I know I've added all the keys that exist to my map.

For that I need a synchronous callback option.