### PR TITLE
Add CallRPCBatch function for efficient batch query

### DIFF
--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -108,4 +108,5 @@ var (
 	MsgInvalidUint64PrecisionLoss  = ffe("FF22090", "String %s cannot be converted to a uint64 without losing precision")
 	MsgInvalidJSONTypeForBigInt    = ffe("FF22091", "JSON parsed '%T' cannot be converted to an integer")
 	MsgHexUintNegative             = ffe("FF22092", "Cannot convert negative integer %d to unsigned")
+	MsgBatchNoResponse             = ffe("FF22093", "No response received in batch for method %s at index %d")
 )

--- a/mocks/rpcbackendmocks/backend.go
+++ b/mocks/rpcbackendmocks/backend.go
@@ -33,6 +33,27 @@ func (_m *Backend) CallRPC(ctx context.Context, result interface{}, method strin
 	return r0
 }
 
+// CallRPCBatch provides a mock function with given fields: ctx, ops
+func (_m *Backend) CallRPCBatch(ctx context.Context, ops ...*rpcbackend.RPCBatchOp) []*rpcbackend.RPCError {
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	for _, op := range ops {
+		_ca = append(_ca, op)
+	}
+	ret := _m.Called(_ca...)
+
+	var r0 []*rpcbackend.RPCError
+	if rf, ok := ret.Get(0).(func(context.Context, ...*rpcbackend.RPCBatchOp) []*rpcbackend.RPCError); ok {
+		r0 = rf(ctx, ops...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*rpcbackend.RPCError)
+		}
+	}
+
+	return r0
+}
+
 // SyncRequest provides a mock function with given fields: ctx, rpcReq
 func (_m *Backend) SyncRequest(ctx context.Context, rpcReq *rpcbackend.RPCRequest) (*rpcbackend.RPCResponse, error) {
 	ret := _m.Called(ctx, rpcReq)

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -45,6 +45,7 @@ type RPC interface {
 }
 
 type BatchRPC interface {
+	RPC
 	CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RPCError
 }
 
@@ -57,7 +58,6 @@ type RPCBatchOp struct {
 
 // Backend performs communication with a backend
 type Backend interface {
-	RPC
 	BatchRPC
 	SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error)
 }

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -44,9 +44,21 @@ type RPC interface {
 	CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError
 }
 
+type BatchRPC interface {
+	CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RPCError
+}
+
+// RPCBatchOp holds the method, params, and result destination for one call within a batch.
+type RPCBatchOp struct {
+	Result interface{}
+	Method string
+	Params []interface{}
+}
+
 // Backend performs communication with a backend
 type Backend interface {
 	RPC
+	BatchRPC
 	SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error)
 }
 
@@ -116,6 +128,19 @@ func (r *RPCResponse) Message() string {
 	return ""
 }
 
+func (rc *RPCClient) reserveConcurrencySlot(ctx context.Context, id any) (func(), *RPCError) {
+	if rc.concurrencySlots == nil {
+		return func() {}, nil
+	}
+	select {
+	case rc.concurrencySlots <- true:
+		return func() { <-rc.concurrencySlots }, nil
+	case <-ctx.Done():
+		err := i18n.NewError(ctx, signermsgs.MsgRequestCanceledContext, id)
+		return nil, &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
+	}
+}
+
 func (rc *RPCClient) allocateRequestID(req *RPCRequest) string {
 	reqID := fmt.Sprintf(`%.9d`, atomic.AddInt64(&rc.requestCounter, 1))
 	req.ID = fftypes.JSONAnyPtr(`"` + reqID + `"`)
@@ -142,24 +167,109 @@ func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method str
 	return nil
 }
 
+func fill[T any](arr []T, v T) []T {
+	for i := range arr {
+		arr[i] = v
+	}
+	return arr
+}
+
+func matchBatchResponse(ctx context.Context, rpcRes *RPCResponse, idToIndex map[string]int, ops []*RPCBatchOp, errs []*RPCError, matched []bool) {
+	if rpcRes == nil || rpcRes.ID == nil {
+		return
+	}
+	var idStr string
+	if jsonErr := json.Unmarshal(rpcRes.ID.Bytes(), &idStr); jsonErr != nil {
+		return
+	}
+	idx, ok := idToIndex[idStr]
+	if !ok {
+		return
+	}
+	matched[idx] = true
+	if rpcRes.Error != nil && rpcRes.Error.Code != 0 {
+		errs[idx] = rpcRes.Error
+		return
+	}
+	result := rpcRes.Result
+	if result == nil {
+		result = fftypes.JSONAnyPtr(fftypes.NullString)
+	}
+	if unmarshalErr := json.Unmarshal(result.Bytes(), ops[idx].Result); unmarshalErr != nil {
+		unmarshalErr = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, ops[idx].Result, unmarshalErr)
+		errs[idx] = &RPCError{Code: int64(RPCCodeParseError), Message: unmarshalErr.Error()}
+	}
+}
+
+func (rc *RPCClient) CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RPCError {
+	errs := make([]*RPCError, len(ops))
+
+	batchReqs := make([]*RPCRequest, len(ops))
+	idToIndex := make(map[string]int, len(ops))
+	for i, op := range ops {
+		rpcReq, rpcErr := buildRequest(ctx, op.Method, op.Params)
+		if rpcErr != nil {
+			errs[i] = rpcErr
+			return errs
+		}
+		rpcReq.JSONRpc = "2.0"
+		idStr := fmt.Sprintf(`%.9d`, atomic.AddInt64(&rc.requestCounter, 1))
+		rpcReq.ID = fftypes.JSONAnyPtr(`"` + idStr + `"`)
+		batchReqs[i] = rpcReq
+		idToIndex[idStr] = i
+	}
+
+	returnSlot, rpcErr := rc.reserveConcurrencySlot(ctx, "batch")
+	if rpcErr != nil {
+		return fill(errs, rpcErr)
+	}
+	defer returnSlot()
+
+	var batchRes []*RPCResponse
+	log.L(ctx).Debugf("RPC batch[%d] -->", len(ops))
+	rpcStartTime := time.Now()
+	res, err := rc.client.R().
+		SetContext(ctx).
+		SetBody(batchReqs).
+		SetResult(&batchRes).
+		Post("")
+	if err != nil {
+		errMsg := i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, err).Error()
+		log.L(ctx).Errorf("RPC batch[%d] <-- ERROR: %s", len(ops), errMsg)
+		return fill(errs, &RPCError{Code: int64(RPCCodeInternalError), Message: errMsg})
+	}
+	log.L(ctx).Infof("RPC batch[%d] <-- [%d] (%.2fms)", len(ops), res.StatusCode(), float64(time.Since(rpcStartTime))/float64(time.Millisecond))
+	if res.IsError() {
+		errMsg := i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, res.Status()).Error()
+		return fill(errs, &RPCError{Code: int64(RPCCodeInternalError), Message: errMsg})
+	}
+
+	matched := make([]bool, len(ops))
+	for _, rpcRes := range batchRes {
+		matchBatchResponse(ctx, rpcRes, idToIndex, ops, errs, matched)
+	}
+
+	for i, op := range ops {
+		if !matched[i] && errs[i] == nil {
+			err := i18n.NewError(ctx, signermsgs.MsgBatchNoResponse, op.Method, i)
+			errs[i] = &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
+		}
+	}
+
+	return errs
+}
+
 // SyncRequest sends an individual RPC request to the backend (always over HTTP currently),
 // and waits synchronously for the response, or an error.
 //
 // In all return paths *including error paths* the RPCResponse is populated
 // so the caller has an RPC structure to send back to the front-end caller.
 func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error) {
-	if rc.concurrencySlots != nil {
-		select {
-		case rc.concurrencySlots <- true:
-			// wait for the concurrency slot and continue
-		case <-ctx.Done():
-			err := i18n.NewError(ctx, signermsgs.MsgRequestCanceledContext, rpcReq.ID)
-			return RPCErrorResponse(err, rpcReq.ID, RPCCodeInternalError), err
-		}
-		defer func() {
-			<-rc.concurrencySlots
-		}()
+	returnSlot, rpcErr := rc.reserveConcurrencySlot(ctx, rpcReq.ID)
+	if rpcErr != nil {
+		return RPCErrorResponse(rpcErr.Error(), rpcReq.ID, RPCCodeInternalError), rpcErr.Error()
 	}
+	defer returnSlot()
 
 	// We always set the back-end request ID - as we need to support requests coming in from
 	// multiple concurrent clients on our front-end that might use clashing IDs.

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -271,6 +271,241 @@ func TestSafeMessageGetter(t *testing.T) {
 	assert.Empty(t, (&RPCResponse{}).Message())
 }
 
+type testBatchRPCHandler func(rpcReqs []*RPCRequest) (int, []*RPCResponse)
+
+func newBatchTestServer(t *testing.T, rpcHandler testBatchRPCHandler) (context.Context, *RPCClient, func()) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rpcReqs []*RPCRequest
+		err := json.NewDecoder(r.Body).Decode(&rpcReqs)
+		assert.NoError(t, err)
+
+		status, rpcResps := rpcHandler(rpcReqs)
+		b, err := json.Marshal(rpcResps)
+		assert.NoError(t, err)
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Content-Length", strconv.Itoa(len(b)))
+		w.WriteHeader(status)
+		w.Write(b)
+	}))
+
+	signerconfig.Reset()
+	prefix := signerconfig.BackendConfig
+	prefix.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s", server.Listener.Addr()))
+	c, err := ffresty.New(ctx, signerconfig.BackendConfig)
+	assert.NoError(t, err)
+	rb := NewRPCClient(c).(*RPCClient)
+
+	return ctx, rb, func() {
+		cancelCtx()
+		server.Close()
+	}
+}
+
+func TestBatchRPCCallOK(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		assert.Len(t, rpcReqs, 2)
+		assert.Equal(t, "eth_blockNumber", rpcReqs[0].Method)
+		assert.Equal(t, "eth_chainId", rpcReqs[1].Method)
+		// Return out of order to verify ID-based matching
+		return 200, []*RPCResponse{
+			{JSONRpc: "2.0", ID: rpcReqs[1].ID, Result: fftypes.JSONAnyPtr(`"0x1"`)},
+			{JSONRpc: "2.0", ID: rpcReqs[0].ID, Result: fftypes.JSONAnyPtr(`"0x100"`)},
+		}
+	})
+	defer done()
+
+	var blockNumber ethtypes.HexInteger
+	var chainID ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx,
+		&RPCBatchOp{Result: &blockNumber, Method: "eth_blockNumber"},
+		&RPCBatchOp{Result: &chainID, Method: "eth_chainId"},
+	)
+	assert.Nil(t, errs[0])
+	assert.Nil(t, errs[1])
+	assert.Equal(t, int64(0x100), blockNumber.BigInt().Int64())
+	assert.Equal(t, int64(0x1), chainID.BigInt().Int64())
+}
+
+func TestBatchRPCCallPartialError(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 200, []*RPCResponse{
+			{JSONRpc: "2.0", ID: rpcReqs[0].ID, Result: fftypes.JSONAnyPtr(`"0x26"`)},
+			{JSONRpc: "2.0", ID: rpcReqs[1].ID, Error: &RPCError{Code: -32000, Message: "not found"}},
+		}
+	})
+	defer done()
+
+	var txCount ethtypes.HexInteger
+	var blockResult ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx,
+		&RPCBatchOp{Result: &txCount, Method: "eth_getTransactionCount", Params: []interface{}{"0xaddr", "pending"}},
+		&RPCBatchOp{Result: &blockResult, Method: "eth_getBlockByHash", Params: []interface{}{"0xbad", false}},
+	)
+	assert.Nil(t, errs[0])
+	assert.Regexp(t, "not found", errs[1])
+	assert.Equal(t, int64(0x26), txCount.BigInt().Int64())
+}
+
+func TestBatchRPCCallBadInput(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 500, nil
+	})
+	defer done()
+
+	var result ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx,
+		&RPCBatchOp{Result: &result, Method: "eth_test", Params: []interface{}{map[bool]bool{false: true}}},
+	)
+	assert.Regexp(t, "FF22011", errs[0])
+}
+
+func TestBatchRPCCallServerDown(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 500, nil
+	})
+	done()
+
+	var result ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx,
+		&RPCBatchOp{Result: &result, Method: "eth_blockNumber"},
+	)
+	assert.Regexp(t, "FF22012", errs[0])
+}
+
+func TestBatchRPCCallConcurrencyCancel(t *testing.T) {
+	blocked := make(chan struct{})
+	blocking := make(chan bool, 1)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		blocking <- true
+		<-blocked
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(500)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	signerconfig.Reset()
+	signerconfig.BackendConfig.Set(ffresty.HTTPConfigURL, server.URL)
+	c, err := ffresty.New(ctx, signerconfig.BackendConfig)
+	assert.NoError(t, err)
+	rb := NewRPCClientWithOption(c, RPCClientOptions{MaxConcurrentRequest: 1}).(*RPCClient)
+
+	bgDone := make(chan struct{})
+	go func() {
+		_, err := rb.SyncRequest(ctx, &RPCRequest{})
+		assert.Regexp(t, "FF22012", err)
+		close(bgDone)
+	}()
+	<-blocking
+
+	cancelCtx()
+	var result ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx, &RPCBatchOp{Result: &result, Method: "eth_blockNumber"})
+	assert.Regexp(t, "FF22063", errs[0])
+
+	close(blocked)
+	<-bgDone
+}
+
+func TestBatchRPCCallHTTPError(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 500, nil
+	})
+	defer done()
+
+	var result ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx, &RPCBatchOp{Result: &result, Method: "eth_blockNumber"})
+	assert.Regexp(t, "FF22012", errs[0])
+}
+
+func TestBatchRPCCallNoResponse(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 200, []*RPCResponse{} // empty — no op matched
+	})
+	defer done()
+
+	var result ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx, &RPCBatchOp{Result: &result, Method: "eth_blockNumber"})
+	assert.Regexp(t, "FF22093", errs[0])
+}
+
+func TestMatchBatchResponseNilResponse(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	matchBatchResponse(context.Background(), nil, map[string]int{}, nil, errs, matched)
+	assert.Nil(t, errs[0])
+	assert.False(t, matched[0])
+}
+
+func TestMatchBatchResponseNilID(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	matchBatchResponse(context.Background(), &RPCResponse{}, map[string]int{}, nil, errs, matched)
+	assert.Nil(t, errs[0])
+	assert.False(t, matched[0])
+}
+
+func TestMatchBatchResponseNonStringID(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	rpcRes := &RPCResponse{ID: fftypes.JSONAnyPtr("123")} // JSON number — unmarshal into string fails
+	matchBatchResponse(context.Background(), rpcRes, map[string]int{"123": 0}, nil, errs, matched)
+	assert.Nil(t, errs[0])
+	assert.False(t, matched[0])
+}
+
+func TestMatchBatchResponseUnknownID(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	rpcRes := &RPCResponse{ID: fftypes.JSONAnyPtr(`"unknown"`)}
+	matchBatchResponse(context.Background(), rpcRes, map[string]int{"other": 0}, nil, errs, matched)
+	assert.Nil(t, errs[0])
+	assert.False(t, matched[0])
+}
+
+func TestMatchBatchResponseRPCError(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	ops := []*RPCBatchOp{{Result: new(ethtypes.HexInteger), Method: "eth_test"}}
+	rpcRes := &RPCResponse{
+		ID:    fftypes.JSONAnyPtr(`"000000001"`),
+		Error: &RPCError{Code: -32000, Message: "oops"},
+	}
+	matchBatchResponse(context.Background(), rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
+	assert.True(t, matched[0])
+	assert.Regexp(t, "oops", errs[0])
+}
+
+func TestMatchBatchResponseNullResult(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	var rawResult *fftypes.JSONAny
+	ops := []*RPCBatchOp{{Result: &rawResult, Method: "eth_test"}}
+	rpcRes := &RPCResponse{
+		ID:     fftypes.JSONAnyPtr(`"000000001"`),
+		Result: nil,
+	}
+	matchBatchResponse(context.Background(), rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
+	assert.True(t, matched[0])
+	assert.Nil(t, errs[0])
+}
+
+func TestMatchBatchResponseUnmarshalFail(t *testing.T) {
+	errs := make([]*RPCError, 1)
+	matched := make([]bool, 1)
+	var mapResult map[string]interface{}
+	ops := []*RPCBatchOp{{Result: &mapResult, Method: "eth_test"}}
+	rpcRes := &RPCResponse{
+		ID:     fftypes.JSONAnyPtr(`"000000001"`),
+		Result: fftypes.JSONAnyPtr(`"not-an-object"`),
+	}
+	matchBatchResponse(context.Background(), rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
+	assert.True(t, matched[0])
+	assert.Regexp(t, "FF22065", errs[0])
+}
+
 func TestSyncRequestConcurrency(t *testing.T) {
 
 	blocked := make(chan struct{})


### PR DESCRIPTION
JSON/RPC 2.0 allows batch query to a runtime, where a set of requests are passed efficiently in an array, and an array of responses (correlated by `id`) is provided.

This PR adds support for this client-side in the `firefly-signer` package.