### PR TITLE
JSON/RPC generic type request/response type to avoid double parsing

### DIFF
--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -111,22 +111,28 @@ func (e *RPCError) String() string {
 	return e.Message
 }
 
-type RPCResponse struct {
+// RPCResponseTyped is a JSON-RPC response envelope that decodes Result directly
+// into T, bypassing the fftypes.JSONAny intermediate used by RPCResponse.
+type RPCResponseTyped[T any] struct {
 	JSONRpc string           `json:"jsonrpc"`
 	ID      *fftypes.JSONAny `json:"id"`
-	Result  *fftypes.JSONAny `json:"result,omitempty"`
+	Result  T                `json:"result,omitempty"`
 	Error   *RPCError        `json:"error,omitempty"`
 	// Only for subscription notifications
 	Method string           `json:"method,omitempty"`
 	Params *fftypes.JSONAny `json:"params,omitempty"`
 }
 
-func (r *RPCResponse) Message() string {
+func (r *RPCResponseTyped[T]) Message() string {
 	if r.Error != nil {
 		return r.Error.Message
 	}
 	return ""
 }
+
+// RPCResponse is the standard JSON-RPC response type, where Result is captured
+// as raw bytes in a fftypes.JSONAny for a second json.Unmarshal by the caller.
+type RPCResponse = RPCResponseTyped[*fftypes.JSONAny]
 
 func (rc *RPCClient) reserveConcurrencySlot(ctx context.Context, id any) (func(), *RPCError) {
 	if rc.concurrencySlots == nil {
@@ -259,15 +265,15 @@ func (rc *RPCClient) CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RP
 	return errs
 }
 
-// SyncRequest sends an individual RPC request to the backend (always over HTTP currently),
-// and waits synchronously for the response, or an error.
-//
-// In all return paths *including error paths* the RPCResponse is populated
-// so the caller has an RPC structure to send back to the front-end caller.
-func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRes *RPCResponse, err error) {
+// syncRequestTyped is the canonical implementation of a single JSON-RPC round-trip.
+// It owns the concurrency slot, request ID allocation, logging, and HTTP call.
+// SyncRequest and CallRPCTyped are thin wrappers around it.
+func syncRequestTyped[T any](ctx context.Context, rc *RPCClient, rpcReq *RPCRequest) (rpcRes RPCResponseTyped[T], err error) {
 	returnSlot, rpcErr := rc.reserveConcurrencySlot(ctx, rpcReq.ID)
 	if rpcErr != nil {
-		return RPCErrorResponse(rpcErr.Error(), rpcReq.ID, RPCCodeInternalError), rpcErr.Error()
+		rpcRes.ID = rpcReq.ID
+		rpcRes.Error = rpcErr
+		return rpcRes, rpcErr.Error()
 	}
 	defer returnSlot()
 
@@ -281,28 +287,26 @@ func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRe
 		rpcTraceID = fmt.Sprintf("%s->%s", rpcReq.ID, rpcTraceID)
 	}
 
-	rpcRes = new(RPCResponse)
-
 	log.L(ctx).Debugf("RPC[%s] --> %s", rpcTraceID, rpcReq.Method)
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		jsonInput, _ := json.Marshal(rpcReq)
 		log.L(ctx).Tracef("RPC[%s] INPUT: %s", rpcTraceID, jsonInput)
 	}
 	rpcStartTime := time.Now()
-	res, err := rc.client.R().
+	res, httpErr := rc.client.R().
 		SetContext(ctx).
 		SetBody(beReq).
 		SetResult(&rpcRes).
-		SetError(rpcRes).
+		SetError(&rpcRes).
 		Post("")
 
 	// Restore the original ID
 	rpcRes.ID = rpcReq.ID
-	if err != nil {
-		err := i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, err)
-		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", rpcTraceID, err)
-		rpcRes = RPCErrorResponse(err, rpcReq.ID, RPCCodeInternalError)
-		return rpcRes, err
+	if httpErr != nil {
+		httpErr = i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, httpErr)
+		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", rpcTraceID, httpErr)
+		rpcRes.Error = &RPCError{Code: int64(RPCCodeInternalError), Message: httpErr.Error()}
+		return rpcRes, httpErr
 	}
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		jsonOutput, _ := json.Marshal(rpcRes)
@@ -319,15 +323,45 @@ func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (rpcRe
 			rpcMsg = i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, res.Status()).Error()
 		}
 		log.L(ctx).Errorf("RPC[%s] <-- [%d]: %s", rpcTraceID, res.StatusCode(), errLog)
-		err := errors.New(rpcMsg)
-		return rpcRes, err
+		return rpcRes, errors.New(rpcMsg)
 	}
 	log.L(ctx).Infof("RPC[%s] <-- %s [%d] OK (%.2fms)", rpcTraceID, rpcReq.Method, res.StatusCode(), float64(time.Since(rpcStartTime))/float64(time.Millisecond))
+	return rpcRes, nil
+}
+
+// SyncRequest sends an individual RPC request to the backend (always over HTTP currently),
+// and waits synchronously for the response, or an error.
+//
+// In all return paths *including error paths* the RPCResponse is populated
+// so the caller has an RPC structure to send back to the front-end caller.
+func (rc *RPCClient) SyncRequest(ctx context.Context, rpcReq *RPCRequest) (*RPCResponse, error) {
+	rpcRes, err := syncRequestTyped[*fftypes.JSONAny](ctx, rc, rpcReq)
+	if err != nil {
+		return &rpcRes, err
+	}
 	if rpcRes.Result == nil {
 		// We don't want a result for errors, but a null success response needs to go in there
 		rpcRes.Result = fftypes.JSONAnyPtr(fftypes.NullString)
 	}
-	return rpcRes, nil
+	return &rpcRes, nil
+}
+
+// CallRPCTyped performs a single JSON-RPC call and decodes the result directly into T.
+// More efficient than parsing into generic JSON bytes result structure first.
+func CallRPCTyped[T any](ctx context.Context, rc *RPCClient, result *T, method string, params ...interface{}) *RPCError {
+	rpcReq, rpcErr := buildRequest(ctx, method, params)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	typed, err := syncRequestTyped[T](ctx, rc, rpcReq)
+	if err != nil {
+		if typed.Error != nil && typed.Error.Code != 0 {
+			return typed.Error
+		}
+		return &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
+	}
+	*result = typed.Result
+	return nil
 }
 
 func RPCErrorResponse(err error, id *fftypes.JSONAny, code RPCCode) *RPCResponse {

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -56,6 +56,14 @@ type RPCBatchOp struct {
 	Params []interface{}
 }
 
+// RPCBatchOpTyped is the typed equivalent of RPCBatchOp for use with CallRPCBatchTyped.
+// All ops in a typed batch must share the same result type T.
+type RPCBatchOpTyped[T any] struct {
+	Result *T
+	Method string
+	Params []interface{}
+}
+
 // Backend performs communication with a backend
 type Backend interface {
 	BatchRPC
@@ -180,7 +188,7 @@ func fill[T any](arr []T, v T) []T {
 	return arr
 }
 
-func matchBatchResponse(ctx context.Context, rpcRes *RPCResponse, idToIndex map[string]int, ops []*RPCBatchOp, errs []*RPCError, matched []bool) {
+func matchBatchResponse[T any](rpcRes *RPCResponseTyped[T], idToIndex map[string]int, ops []*RPCBatchOpTyped[T], errs []*RPCError, matched []bool) {
 	if rpcRes == nil || rpcRes.ID == nil {
 		return
 	}
@@ -197,17 +205,40 @@ func matchBatchResponse(ctx context.Context, rpcRes *RPCResponse, idToIndex map[
 		errs[idx] = rpcRes.Error
 		return
 	}
-	result := rpcRes.Result
-	if result == nil {
-		result = fftypes.JSONAnyPtr(fftypes.NullString)
-	}
-	if unmarshalErr := json.Unmarshal(result.Bytes(), ops[idx].Result); unmarshalErr != nil {
-		unmarshalErr = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, ops[idx].Result, unmarshalErr)
-		errs[idx] = &RPCError{Code: int64(RPCCodeParseError), Message: unmarshalErr.Error()}
-	}
+	*ops[idx].Result = rpcRes.Result
 }
 
 func (rc *RPCClient) CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RPCError {
+	typedOps := make([]*RPCBatchOpTyped[*fftypes.JSONAny], len(ops))
+	intermediates := make([]*fftypes.JSONAny, len(ops))
+	for i, op := range ops {
+		typedOps[i] = &RPCBatchOpTyped[*fftypes.JSONAny]{
+			Result: &intermediates[i],
+			Method: op.Method,
+			Params: op.Params,
+		}
+	}
+	errs := CallRPCBatchTyped(ctx, rc, typedOps...)
+	for i, op := range ops {
+		if errs[i] != nil {
+			continue
+		}
+		result := intermediates[i]
+		if result == nil {
+			result = fftypes.JSONAnyPtr(fftypes.NullString)
+		}
+		if unmarshalErr := json.Unmarshal(result.Bytes(), op.Result); unmarshalErr != nil {
+			unmarshalErr = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, op.Result, unmarshalErr)
+			errs[i] = &RPCError{Code: int64(RPCCodeParseError), Message: unmarshalErr.Error()}
+		}
+	}
+	return errs
+}
+
+// CallRPCBatchTyped sends a JSON-RPC batch where every operation decodes its result directly
+// into T, bypassing the fftypes.JSONAny intermediate used by CallRPCBatch.
+// All ops in the batch must share the same result type.
+func CallRPCBatchTyped[T any](ctx context.Context, rc *RPCClient, ops ...*RPCBatchOpTyped[T]) []*RPCError {
 	errs := make([]*RPCError, len(ops))
 
 	batchReqs := make([]*RPCRequest, len(ops))
@@ -231,7 +262,7 @@ func (rc *RPCClient) CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RP
 	}
 	defer returnSlot()
 
-	var batchRes []*RPCResponse
+	var batchRes []*RPCResponseTyped[T]
 	log.L(ctx).Debugf("RPC batch[%d] -->", len(ops))
 	rpcStartTime := time.Now()
 	res, err := rc.client.R().
@@ -252,7 +283,7 @@ func (rc *RPCClient) CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RP
 
 	matched := make([]bool, len(ops))
 	for _, rpcRes := range batchRes {
-		matchBatchResponse(ctx, rpcRes, idToIndex, ops, errs, matched)
+		matchBatchResponse(rpcRes, idToIndex, ops, errs, matched)
 	}
 
 	for i, op := range ops {

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -465,6 +465,50 @@ func TestMatchBatchResponseUnknownID(t *testing.T) {
 	assert.False(t, matched[0])
 }
 
+func TestCallRPCTypedOK(t *testing.T) {
+
+	ctx, rb, done := newTestServer(t, func(rpcReq *RPCRequest) (status int, rpcRes *RPCResponse) {
+		return 200, &RPCResponse{
+			JSONRpc: "2.0",
+			ID:      rpcReq.ID,
+			Result:  fftypes.JSONAnyPtr(`"0x26"`),
+		}
+	})
+	defer done()
+
+	var txCount ethtypes.HexInteger
+	rpcErr := CallRPCTyped(ctx, rb, &txCount, "eth_getTransactionCount", ethtypes.MustNewAddress("0xfb075bb99f2aa4c49955bf703509a227d7a12248"), "pending")
+	assert.Nil(t, rpcErr)
+	assert.Equal(t, int64(0x26), txCount.BigInt().Int64())
+}
+
+func TestCallRPCTypedRPCError(t *testing.T) {
+
+	ctx, rb, done := newTestServer(t, func(rpcReq *RPCRequest) (status int, rpcRes *RPCResponse) {
+		return 200, &RPCResponse{
+			JSONRpc: "2.0",
+			ID:      rpcReq.ID,
+			Error:   &RPCError{Code: -32000, Message: "not found"},
+		}
+	})
+	defer done()
+
+	var txCount ethtypes.HexInteger
+	rpcErr := CallRPCTyped(ctx, rb, &txCount, "eth_getTransactionByHash", "0x1234")
+	assert.Regexp(t, "not found", rpcErr.Error())
+	assert.Equal(t, int64(-32000), rpcErr.Code)
+}
+
+func TestCallRPCTypedBadInput(t *testing.T) {
+
+	ctx, rb, done := newTestServer(t, func(rpcReq *RPCRequest) (status int, rpcRes *RPCResponse) { return 500, nil })
+	defer done()
+
+	var txCount ethtypes.HexInteger
+	rpcErr := CallRPCTyped(ctx, rb, &txCount, "test-bad-params", map[bool]bool{false: true})
+	assert.Regexp(t, "FF22011", rpcErr.Error())
+}
+
 func TestMatchBatchResponseRPCError(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -271,6 +271,16 @@ func TestSafeMessageGetter(t *testing.T) {
 	assert.Empty(t, (&RPCResponse{}).Message())
 }
 
+func TestRPCErrorResponse(t *testing.T) {
+
+	id := fftypes.JSONAnyPtr(`"test-id"`)
+	res := RPCErrorResponse(fmt.Errorf("something went wrong"), id, RPCCodeInternalError)
+	assert.Equal(t, "2.0", res.JSONRpc)
+	assert.Equal(t, id, res.ID)
+	assert.Equal(t, int64(RPCCodeInternalError), res.Error.Code)
+	assert.Equal(t, "something went wrong", res.Error.Message)
+}
+
 type testBatchRPCHandler func(rpcReqs []*RPCRequest) (int, []*RPCResponse)
 
 func newBatchTestServer(t *testing.T, rpcHandler testBatchRPCHandler) (context.Context, *RPCClient, func()) {
@@ -431,10 +441,27 @@ func TestBatchRPCCallNoResponse(t *testing.T) {
 	assert.Regexp(t, "FF22093", errs[0])
 }
 
+func TestBatchRPCCallNullResult(t *testing.T) {
+
+	// Server returns null result — matchBatchResponse assigns nil to the intermediate,
+	// CallRPCBatch converts nil → fftypes.NullString before the final json.Unmarshal.
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 200, []*RPCResponse{
+			{JSONRpc: "2.0", ID: rpcReqs[0].ID, Result: nil},
+		}
+	})
+	defer done()
+
+	var result *ethtypes.HexInteger
+	errs := rb.CallRPCBatch(ctx, &RPCBatchOp{Result: &result, Method: "eth_getTransactionReceipt"})
+	assert.Nil(t, errs[0])
+	assert.Nil(t, result)
+}
+
 func TestMatchBatchResponseNilResponse(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)
-	matchBatchResponse(context.Background(), nil, map[string]int{}, nil, errs, matched)
+	matchBatchResponse[any](nil, map[string]int{}, nil, errs, matched)
 	assert.Nil(t, errs[0])
 	assert.False(t, matched[0])
 }
@@ -442,7 +469,7 @@ func TestMatchBatchResponseNilResponse(t *testing.T) {
 func TestMatchBatchResponseNilID(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)
-	matchBatchResponse(context.Background(), &RPCResponse{}, map[string]int{}, nil, errs, matched)
+	matchBatchResponse(&RPCResponse{}, map[string]int{}, nil, errs, matched)
 	assert.Nil(t, errs[0])
 	assert.False(t, matched[0])
 }
@@ -451,7 +478,7 @@ func TestMatchBatchResponseNonStringID(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)
 	rpcRes := &RPCResponse{ID: fftypes.JSONAnyPtr("123")} // JSON number — unmarshal into string fails
-	matchBatchResponse(context.Background(), rpcRes, map[string]int{"123": 0}, nil, errs, matched)
+	matchBatchResponse(rpcRes, map[string]int{"123": 0}, nil, errs, matched)
 	assert.Nil(t, errs[0])
 	assert.False(t, matched[0])
 }
@@ -460,7 +487,7 @@ func TestMatchBatchResponseUnknownID(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)
 	rpcRes := &RPCResponse{ID: fftypes.JSONAnyPtr(`"unknown"`)}
-	matchBatchResponse(context.Background(), rpcRes, map[string]int{"other": 0}, nil, errs, matched)
+	matchBatchResponse(rpcRes, map[string]int{"other": 0}, nil, errs, matched)
 	assert.Nil(t, errs[0])
 	assert.False(t, matched[0])
 }
@@ -509,15 +536,30 @@ func TestCallRPCTypedBadInput(t *testing.T) {
 	assert.Regexp(t, "FF22011", rpcErr.Error())
 }
 
+func TestCallRPCTypedHTTPErrorNoRPCBody(t *testing.T) {
+
+	// 500 with no RPCResponse body — syncRequestTyped returns err but typed.Error is nil,
+	// so CallRPCTyped must fall through to the generic error path.
+	ctx, rb, done := newTestServer(t, func(rpcReq *RPCRequest) (status int, rpcRes *RPCResponse) {
+		return 500, nil
+	})
+	defer done()
+
+	var txCount ethtypes.HexInteger
+	rpcErr := CallRPCTyped(ctx, rb, &txCount, "eth_blockNumber")
+	assert.Regexp(t, "FF22012", rpcErr.Error())
+}
+
 func TestMatchBatchResponseRPCError(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)
-	ops := []*RPCBatchOp{{Result: new(ethtypes.HexInteger), Method: "eth_test"}}
-	rpcRes := &RPCResponse{
+	result := new(ethtypes.HexInteger)
+	ops := []*RPCBatchOpTyped[ethtypes.HexInteger]{{Result: result, Method: "eth_test"}}
+	rpcRes := &RPCResponseTyped[ethtypes.HexInteger]{
 		ID:    fftypes.JSONAnyPtr(`"000000001"`),
 		Error: &RPCError{Code: -32000, Message: "oops"},
 	}
-	matchBatchResponse(context.Background(), rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
+	matchBatchResponse[ethtypes.HexInteger](rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
 	assert.True(t, matched[0])
 	assert.Regexp(t, "oops", errs[0])
 }
@@ -526,27 +568,26 @@ func TestMatchBatchResponseNullResult(t *testing.T) {
 	errs := make([]*RPCError, 1)
 	matched := make([]bool, 1)
 	var rawResult *fftypes.JSONAny
-	ops := []*RPCBatchOp{{Result: &rawResult, Method: "eth_test"}}
+	ops := []*RPCBatchOpTyped[*fftypes.JSONAny]{{Result: &rawResult, Method: "eth_test"}}
 	rpcRes := &RPCResponse{
 		ID:     fftypes.JSONAnyPtr(`"000000001"`),
 		Result: nil,
 	}
-	matchBatchResponse(context.Background(), rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
+	matchBatchResponse(rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
 	assert.True(t, matched[0])
 	assert.Nil(t, errs[0])
 }
 
-func TestMatchBatchResponseUnmarshalFail(t *testing.T) {
-	errs := make([]*RPCError, 1)
-	matched := make([]bool, 1)
+func TestBatchRPCCallUnmarshalFail(t *testing.T) {
+	ctx, rb, done := newBatchTestServer(t, func(rpcReqs []*RPCRequest) (int, []*RPCResponse) {
+		return 200, []*RPCResponse{
+			{JSONRpc: "2.0", ID: rpcReqs[0].ID, Result: fftypes.JSONAnyPtr(`"not-an-object"`)},
+		}
+	})
+	defer done()
+
 	var mapResult map[string]interface{}
-	ops := []*RPCBatchOp{{Result: &mapResult, Method: "eth_test"}}
-	rpcRes := &RPCResponse{
-		ID:     fftypes.JSONAnyPtr(`"000000001"`),
-		Result: fftypes.JSONAnyPtr(`"not-an-object"`),
-	}
-	matchBatchResponse(context.Background(), rpcRes, map[string]int{"000000001": 0}, ops, errs, matched)
-	assert.True(t, matched[0])
+	errs := rb.CallRPCBatch(ctx, &RPCBatchOp{Result: &mapResult, Method: "eth_test"})
 	assert.Regexp(t, "FF22065", errs[0])
 }
 


### PR DESCRIPTION
For high performance JSON/RPC heavy applications the two-step parsing in `rpcbackend` where it uses a `fftypes.JSONAny` then parses from that into the supplied `interface{}` is inefficient.

This can be solved with generic based functions that are typed to the result.

- `CallRPCTyped` - for a single call
- `CallRPCBatchTyped` - for a batch of types _with the same result type_

Care is taken this PR to avoid any interface change on the existing functions, while also striving to avoid code duplication.