### PR TITLE
update V value manipulation

### DIFF
--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -100,7 +100,7 @@ var (
 	MsgUnsupportedTransactionType  = ffe("FF22082", "Unsupported transaction type 0x%02x")
 	MsgInvalidLegacyTransaction    = ffe("FF22083", "Transaction payload invalid (legacy): %v")
 	MsgInvalidEIP1559Transaction   = ffe("FF22084", "Transaction payload invalid (EIP-1559): %v")
-	MsgInvalidEIP155TransactionV   = ffe("FF22085", "Invalid V value from EIP-155 transaction (chainId=%d)")
+	MsgInvalidEIP155TransactionV   = ffe("FF22085", "Invalid V value from EIP-155 transaction (chainId=%d, V=%d)")
 	MsgInvalidChainID              = ffe("FF22086", "Invalid chainId expected=%d actual=%d")
 	MsgSigningInvalidCompactRSV    = ffe("FF22087", "Invalid signature data (compact R,S,V) length=%d (expected=65)")
 	MsgInvalidNumberString         = ffe("FF22088", "Invalid integer string '%s'")

--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -154,6 +154,11 @@ func (t *Transaction) SignLegacyOriginal(signer secp256k1.Signer) ([]byte, error
 }
 
 func (t *Transaction) FinalizeLegacyOriginalWithSignature(signaturePayload *TransactionSignaturePayload, sig *secp256k1.SignatureData) ([]byte, error) {
+	// Use the pre-EIP-155 V value (27/28)
+	err := sig.UpdateOriginal()
+	if err != nil {
+		return nil, err
+	}
 	rlpList := t.addSignature(signaturePayload.rlpList, sig)
 	return rlpList.Encode(), nil
 }
@@ -187,8 +192,10 @@ func (t *Transaction) SignLegacyEIP155(signer secp256k1.Signer, chainID int64) (
 
 func (t *Transaction) FinalizeLegacyEIP155WithSignature(signaturePayload *TransactionSignaturePayload, sig *secp256k1.SignatureData, chainID int64) ([]byte, error) {
 	// Use the EIP-155 V value, of (2*ChainID + 35 + Y-parity)
-	sig.UpdateEIP155(chainID)
-
+	err := sig.UpdateEIP155(chainID)
+	if err != nil {
+		return nil, err
+	}
 	rlpList := t.addSignature(signaturePayload.rlpList[0:6] /* we don't include the chainID+0+0 hash values in the payload */, sig)
 	return rlpList.Encode(), nil
 }
@@ -222,7 +229,10 @@ func (t *Transaction) SignEIP1559(signer secp256k1.Signer, chainID int64) ([]byt
 
 func (t *Transaction) FinalizeEIP1559WithSignature(signaturePayload *TransactionSignaturePayload, sig *secp256k1.SignatureData) ([]byte, error) {
 	// Use the direct 0/1 Y-parity value
-	sig.UpdateEIP2930()
+	err := sig.UpdateEIP2930()
+	if err != nil {
+		return nil, err
+	}
 
 	// Now we need a new RLP array, _including_ signature
 	// 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s])
@@ -256,13 +266,12 @@ func RecoverLegacyRawTransaction(ctx context.Context, rawTx ethtypes.HexBytes0xP
 	vValue := rlpList[6].ToData().Int().Int64()
 	rValue := rlpList[7].ToData().BytesNotNil()
 	sValue := rlpList[8].ToData().BytesNotNil()
-
 	var message []byte
 	if vValue != 27 && vValue != 28 {
 		// Legacy with EIP155 extensions
-		vValue = vValue - (chainID * 2) - 8
-		if vValue != 27 && vValue != 28 {
-			return nil, nil, i18n.NewError(ctx, signermsgs.MsgInvalidEIP155TransactionV, chainID)
+		yParity := vValue - (chainID * 2) - 35
+		if yParity != 0 && yParity != 1 {
+			return nil, nil, i18n.NewError(ctx, signermsgs.MsgInvalidEIP155TransactionV, chainID, vValue)
 		}
 
 		signedRLPList := make(rlp.List, 6, 9)

--- a/pkg/ethsigner/typed_data.go
+++ b/pkg/ethsigner/typed_data.go
@@ -43,6 +43,11 @@ func SignTypedDataV4(ctx context.Context, signer secp256k1.SignerDirect, payload
 		return nil, err
 	}
 
+	err = sig.UpdateOriginal()
+	if err != nil {
+		return nil, err
+	}
+
 	signatureBytes := make([]byte, 65)
 	sig.R.FillBytes(signatureBytes[0:32])
 	sig.S.FillBytes(signatureBytes[32:64])

--- a/pkg/secp256k1/keypair_test.go
+++ b/pkg/secp256k1/keypair_test.go
@@ -51,6 +51,18 @@ func TestGeneratedKeyRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, keypair.Address, *addr)
 
+	// For V that's 0/1, we should get the same address
+	if sig.V.Int64() == 27 {
+		sig.V.SetInt64(0)
+	} else if sig.V.Int64() == 28 {
+		sig.V.SetInt64(1)
+	} else {
+		t.Fatalf("unexpected V value: %d (must be 27/28 as btcec was used for signing)", sig.V.Int64())
+	}
+	addr, err = sig.Recover(data, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, keypair.Address, *addr)
+
 	// Latest 0/1 - EIP-1559 / EIP-2930
 	err = sig.UpdateEIP2930()
 	assert.NoError(t, err)

--- a/pkg/secp256k1/keypair_test.go
+++ b/pkg/secp256k1/keypair_test.go
@@ -45,15 +45,23 @@ func TestGeneratedKeyRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, keypair.Address, *addr)
 
+	err = sig.UpdateOriginal() // this should be a no-op for 27/28
+	assert.NoError(t, err)
+	addr, err = sig.Recover(data, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, keypair.Address, *addr)
+
 	// Latest 0/1 - EIP-1559 / EIP-2930
-	sig.UpdateEIP2930()
+	err = sig.UpdateEIP2930()
+	assert.NoError(t, err)
 	addr, err = sig.Recover(data, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, keypair.Address, *addr)
 	sig.V.SetInt64(sig.V.Int64() + 27)
 
 	// Chain ID encoded in V value - EIP-155
-	sig.UpdateEIP155(1001)
+	err = sig.UpdateEIP155(1001)
+	assert.NoError(t, err)
 	addr, err = sig.Recover(data, 1001)
 	assert.NoError(t, err)
 	assert.Equal(t, keypair.Address, *addr)

--- a/pkg/secp256k1/signer.go
+++ b/pkg/secp256k1/signer.go
@@ -62,7 +62,7 @@ func (s *SignatureData) getVNormalized(chainID int64) (byte, error) {
 	return vB, nil
 }
 
-func (s *SignatureData) setVToYParity() error {
+func (s *SignatureData) normalizeVToYParity() error {
 	switch s.V.Int64() {
 	case 0, 1:
 		// do nothing
@@ -90,7 +90,7 @@ func (s *SignatureData) UpdateOriginal() error {
 func (s *SignatureData) UpdateEIP155(chainID int64) error {
 	chainIDx2 := big.NewInt(chainID)
 	chainIDx2 = chainIDx2.Mul(chainIDx2, big.NewInt(2))
-	err := s.setVToYParity()
+	err := s.normalizeVToYParity()
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (s *SignatureData) UpdateEIP155(chainID int64) error {
 
 // EIP-2930 (/ EIP-1559) rules - 0 or 1 V value for raw Y-parity value (chainID goes into the payload)
 func (s *SignatureData) UpdateEIP2930() error {
-	return s.setVToYParity()
+	return s.normalizeVToYParity()
 }
 
 // Recover obtains the original signer from the hash of the message

--- a/pkg/secp256k1/signer.go
+++ b/pkg/secp256k1/signer.go
@@ -62,20 +62,45 @@ func (s *SignatureData) getVNormalized(chainID int64) (byte, error) {
 	return vB, nil
 }
 
-// EIP-155 rules - 2xChainID + 35 - starting point must be legacy 27/28
-func (s *SignatureData) UpdateEIP155(chainID int64) {
+func (s *SignatureData) setVToYParity() error {
+	switch s.V.Int64() {
+	case 0, 1:
+		// do nothing
+	case 27, 28:
+		s.V = s.V.Sub(s.V, big.NewInt(27))
+	}
+	if s.V.Int64() != 0 && s.V.Int64() != 1 {
+		return fmt.Errorf("cannot recover Y-parity value from V = %d (V must be 0/1 or 27/28)", s.V.Int64())
+	}
+	return nil
+}
+
+// UpdateOriginal uses the original 27/28 V value (pre-EIP-155)
+func (s *SignatureData) UpdateOriginal() error {
+	vi64 := s.V.Int64()
+	if vi64 == 0 || vi64 == 1 {
+		s.V = s.V.Add(s.V, big.NewInt(27))
+	} else if vi64 != 27 && vi64 != 28 {
+		return fmt.Errorf("invalid V value in signature V = %d (V must be 0/1 or 27/28)", vi64)
+	}
+	return nil
+}
+
+// EIP-155 rules - 2xChainID + 35 + y-parity
+func (s *SignatureData) UpdateEIP155(chainID int64) error {
 	chainIDx2 := big.NewInt(chainID)
 	chainIDx2 = chainIDx2.Mul(chainIDx2, big.NewInt(2))
-	s.V = s.V.Add(s.V, chainIDx2).Add(s.V, big.NewInt(35-27))
-
+	err := s.setVToYParity()
+	if err != nil {
+		return err
+	}
+	s.V = s.V.Add(s.V, chainIDx2).Add(s.V, big.NewInt(35))
+	return nil
 }
 
 // EIP-2930 (/ EIP-1559) rules - 0 or 1 V value for raw Y-parity value (chainID goes into the payload)
-func (s *SignatureData) UpdateEIP2930() {
-	vi64 := s.V.Int64()
-	if vi64 == 27 || vi64 == 28 {
-		s.V = s.V.Sub(s.V, big.NewInt(27))
-	}
+func (s *SignatureData) UpdateEIP2930() error {
+	return s.setVToYParity()
 }
 
 // Recover obtains the original signer from the hash of the message

--- a/pkg/secp256k1/signer_test.go
+++ b/pkg/secp256k1/signer_test.go
@@ -19,6 +19,7 @@ package secp256k1
 import (
 	"bytes"
 	"encoding/hex"
+	"math/big"
 	"strconv"
 	"testing"
 
@@ -74,8 +75,39 @@ func TestSignMessage(t *testing.T) {
 	assert.Equal(t, "0464eee9e2fe1a10ffe48c78b80de1ed8dcf996f3f60955cb2e03cb21903d930", ((ethtypes.HexBytesPlain)(sig.R.Bytes())).String())
 	assert.Equal(t, "06624da478b3f862582e85b31c6a21c6cae2eee2bd50f55c93c4faad9d9c8d7f", ((ethtypes.HexBytesPlain)(sig.S.Bytes())).String())
 
-	sig.UpdateEIP155(1001)
+	err = sig.UpdateEIP155(1001)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(2038), sig.V.Int64())
+}
+
+func TestUpdateEIP155Error(t *testing.T) {
+	sig := &SignatureData{
+		V: big.NewInt(42),
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	err := sig.UpdateEIP155(1001)
+	assert.Regexp(t, "cannot recover Y-parity value", err)
+}
+
+func TestUpdateEIP2930Error(t *testing.T) {
+	sig := &SignatureData{
+		V: big.NewInt(42),
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	err := sig.UpdateEIP2930()
+	assert.Regexp(t, "cannot recover Y-parity value", err)
+}
+
+func TestUpdateOriginalError(t *testing.T) {
+	sig := &SignatureData{
+		V: big.NewInt(42),
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	err := sig.UpdateOriginal()
+	assert.Regexp(t, "invalid V value in signature", err)
 }
 
 func TestSignFailNil(t *testing.T) {


### PR DESCRIPTION
Update the logic for calculating `v` value so that it can work with an RSV signature in which `v` is just the y parity. 



The diagram and tables below show the changes:

<img width="1383" height="508" alt="image" src="https://github.com/user-attachments/assets/954e430f-6dad-4101-ad9a-7a0208458efe" />


## Before the fix

| Func \ Input V | A (0/1) | B (27/28) | C (2064/2065) | E (98112/119) |
| - | - | - | - | - |
| 1 (expect A, B, C)| ✅  | ✅  | ✅  | ✅  (throws unexpected V error) |
| 2 (expects B) | 🔴  (0/1)  |  ✅  (27/28)  |   🔴 (2064/2065)  |  🔴 (98112/119) |
| 3 (expects C) | 🔴  (2010/2011) | ✅   (2064/2065)  |  🔴  (4047/4048)  | 🔴 (100122/2129) |
| 4 (expects A)  | ✅ (0/1)  | ✅  (0/1)  | 🔴 (2064/2065)  | 🔴  (98112/119) |



## After the fix 

| Func \ Input V | A (0/1) | B (27/28) | C (2064/2065) | E (98112/119) |
| - | - | - | - | - |
| 1 (expect A, B, C)| ✅  | ✅  | ✅  | ✅  (throws unexpected V error) |
| 2 (expects B) |  ✅  (27/28)  |  ✅  (27/28)  |  ✅  (throws unexpected V error)  |  ✅  (throws unexpected V error) |
| 3 (expects C) | ✅   (2064/2065)  | ✅   (2064/2065)  |  ✅  (throws unexpected V error)   | ✅  (throws unexpected V error)  |
| 4 (expects A)  | ✅ (0/1)  | ✅  (0/1)  | ✅  (throws unexpected V error)   | ✅  (throws unexpected V error)  |


# Key changes are:
- Align function `2`, `3`, `4` with `1`: explicit error when the `Input V` is not expected (either widely adopted Y-parity or the values conforming to the corresponding rules)
-  Align function `2` , `3` with `4`: handle `Input V` with Y-parity as value.