### PR TITLE
ensure null value are parsed correctly

### DIFF
--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -161,6 +161,17 @@ func (rc *RPCClient) allocateRequestID(req *RPCRequest) string {
 	return reqID
 }
 
+// unmarshalRPCResult decodes a JSON-RPC result payload into the caller's target,
+// treating an absent payload as JSON null. A success response with "result": null
+// decodes to a nil JSONAny
+func unmarshalRPCResult(data *fftypes.JSONAny, target interface{}) error {
+	b := data.Bytes()
+	if len(b) == 0 {
+		b = []byte(fftypes.NullString)
+	}
+	return json.Unmarshal(b, target)
+}
+
 func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *RPCError {
 	start := time.Now()
 	rpcReq, rpcErr := buildRequest(ctx, method, params)
@@ -180,7 +191,7 @@ func (rc *RPCClient) CallRPC(ctx context.Context, result interface{}, method str
 		}
 		return &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
 	}
-	err = json.Unmarshal(res.Result.Bytes(), &result)
+	err = unmarshalRPCResult(res.Result, &result)
 	if err != nil {
 		err = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, result, err)
 		recordRPCRequest(ctx, method, statusParseError, false, time.Since(start))
@@ -232,11 +243,7 @@ func (rc *RPCClient) CallRPCBatch(ctx context.Context, ops ...*RPCBatchOp) []*RP
 		if errs[i] != nil {
 			continue
 		}
-		result := intermediates[i]
-		if result == nil {
-			result = fftypes.JSONAnyPtr(fftypes.NullString)
-		}
-		if unmarshalErr := json.Unmarshal(result.Bytes(), op.Result); unmarshalErr != nil {
+		if unmarshalErr := unmarshalRPCResult(intermediates[i], op.Result); unmarshalErr != nil {
 			unmarshalErr = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, op.Result, unmarshalErr)
 			errs[i] = &RPCError{Code: int64(RPCCodeParseError), Message: unmarshalErr.Error()}
 		}

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -246,6 +246,27 @@ func TestSyncRPCCallFailParseJSONResponse(t *testing.T) {
 	assert.Regexp(t, "FF22065", rpcErr.Error())
 }
 
+func TestSyncRPCCallNullResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"000000001","result":null}`))
+	}))
+	defer server.Close()
+
+	signerconfig.Reset()
+	prefix := signerconfig.BackendConfig
+	prefix.Set(ffresty.HTTPConfigURL, server.URL)
+	c, err := ffresty.New(context.Background(), signerconfig.BackendConfig)
+	assert.NoError(t, err)
+	rb := NewRPCClient(c).(*RPCClient)
+
+	receipt := &map[string]interface{}{}
+	rpcErr := rb.CallRPC(context.Background(), &receipt, "eth_getTransactionReceipt", "0x61ca9c99c1d752fb3bda568b8566edf33ba93585c64a970566e6dfb540a5cbc1")
+	assert.Nil(t, rpcErr)
+	assert.Nil(t, receipt)
+}
+
 func TestSyncRPCCallErrorBadInput(t *testing.T) {
 
 	ctx, rb, done := newTestServer(t, func(rpcReq *RPCRequest) (status int, rpcRes *RPCResponse) { return 500, nil })

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -393,12 +393,8 @@ func (rc *wsRPCClient) waitResponse(ctx context.Context, result interface{}, req
 		return rpcRes.Error
 	}
 	log.L(ctx).Infof("RPC[%s] <-- %s OK (%s)", reqID, rpcReq.Method, time.Since(start))
-	if rpcRes.Result == nil {
-		// We don't want a result for errors, but a null success response needs to go in there
-		rpcRes.Result = fftypes.JSONAnyPtr(fftypes.NullString)
-	}
 	if result != nil {
-		if err := json.Unmarshal(rpcRes.Result.Bytes(), &result); err != nil {
+		if err := unmarshalRPCResult(rpcRes.Result, &result); err != nil {
 			err = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, result, err)
 			recordRPCRequest(ctx, rpcReq.Method, statusParseError, false, time.Since(start))
 			return &RPCError{Code: int64(RPCCodeParseError), Message: err.Error()}

--- a/pkg/rpcbackend/wsbackend_test.go
+++ b/pkg/rpcbackend/wsbackend_test.go
@@ -250,6 +250,27 @@ func TestCallRPC(t *testing.T) {
 	done()
 }
 
+func TestCallRPCNullResult(t *testing.T) {
+	ctx, rc, toServer, fromServer, done := newTestWSRPC(t)
+
+	err := rc.Connect(context.Background())
+	assert.NoError(t, err)
+
+	go func() {
+		msg := <-toServer
+		assert.JSONEq(t, `{"jsonrpc":"2.0","id":"000000001","method":"eth_getTransactionReceipt","params":["0x61ca9c99c1d752fb3bda568b8566edf33ba93585c64a970566e6dfb540a5cbc1"]}`, msg)
+		fromServer <- `{"jsonrpc":"2.0","id":"000000001","result":null}`
+	}()
+
+	// A success with "result": null must decode to a nil result rather than failing to parse
+	receipt := &map[string]interface{}{}
+	rpcErr := rc.CallRPC(ctx, &receipt, "eth_getTransactionReceipt", "0x61ca9c99c1d752fb3bda568b8566edf33ba93585c64a970566e6dfb540a5cbc1")
+	assert.Nil(t, rpcErr)
+	assert.Nil(t, receipt)
+
+	done()
+}
+
 func TestWaitResponseClosedContext(t *testing.T) {
 	ctx, rc, _, _, done := newTestWSRPC(t)
 


### PR DESCRIPTION
As part of https://github.com/hyperledger-firefly/signer/pull/100/changes#diff-2aad17c4690b0c1fa07321da007ac247e464434b5619e1350b48b8a0a63550d6L169 I switched the `CallRPC` function to use the internal function `syncRequestTyped` for metrics recording based on http response status.

However, this introduced a regression because the safeguarding logic of responses that contain `result: null` is in the wrapper function `SyncRequest`. This PR fixes the regression by applying the safeguarding logic in the regressed code path with a test added.

 Also, refactored out the common logic.