### PR TITLE
fix(ffi2abi): positional names for anonymous ABI parameters

### DIFF
--- a/pkg/ffi2abi/ffi.go
+++ b/pkg/ffi2abi/ffi.go
@@ -19,6 +19,7 @@ package ffi2abi
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/hyperledger-firefly/common/pkg/fftypes"
@@ -135,6 +136,17 @@ func ConvertFFIErrorDefinitionToABI(ctx context.Context, errorDef *fftypes.FFIEr
 	return abiEntry, nil
 }
 
+// abiParamName returns the name of an ABI parameter, falling back to its positional
+// index for anonymous (unnamed) parameters. This matches the defaults used by the
+// abi package when parsing inputs and serializing outputs, and ensures FFI params
+// and generated JSON schemas have unique, non-empty property names.
+func abiParamName(name string, index int) string {
+	if name == "" {
+		return strconv.Itoa(index)
+	}
+	return name
+}
+
 func ConvertABIToFFI(ctx context.Context, ns, name, version, description string, abi *abi.ABI) (*fftypes.FFI, error) {
 	ffi := &fftypes.FFI{
 		Namespace:   ns,
@@ -186,7 +198,7 @@ func convertABIFunctionToFFIMethod(ctx context.Context, abiFunction *abi.Entry) 
 		}
 		schema := getSchemaForABIInput(ctx, typeComponent)
 		param := &fftypes.FFIParam{
-			Name:   input.Name,
+			Name:   abiParamName(input.Name, i),
 			Schema: fftypes.JSONAnyPtr(schema.ToJSON()),
 		}
 		params[i] = param
@@ -198,7 +210,7 @@ func convertABIFunctionToFFIMethod(ctx context.Context, abiFunction *abi.Entry) 
 		}
 		schema := getSchemaForABIInput(ctx, typeComponent)
 		param := &fftypes.FFIParam{
-			Name:   output.Name,
+			Name:   abiParamName(output.Name, i),
 			Schema: fftypes.JSONAnyPtr(schema.ToJSON()),
 		}
 		returns[i] = param
@@ -230,7 +242,7 @@ func convertABIEventToFFIEvent(ctx context.Context, abiEvent *abi.Entry) (*fftyp
 		}
 		schema := getSchemaForABIInput(ctx, typeComponent)
 		param := &fftypes.FFIParam{
-			Name:   output.Name,
+			Name:   abiParamName(output.Name, i),
 			Schema: fftypes.JSONAnyPtr(schema.ToJSON()),
 		}
 		params[i] = param
@@ -256,7 +268,7 @@ func convertABIErrorToFFIError(ctx context.Context, abiError *abi.Entry) (*fftyp
 		}
 		schema := getSchemaForABIInput(ctx, typeComponent)
 		param := &fftypes.FFIParam{
-			Name:   input.Name,
+			Name:   abiParamName(input.Name, i),
 			Schema: fftypes.JSONAnyPtr(schema.ToJSON()),
 		}
 		params[i] = param
@@ -317,7 +329,7 @@ func getSchemaForABIInput(ctx context.Context, typeComponent abi.TypeComponent) 
 			childSchema := getSchemaForABIInput(ctx, tupleChild)
 			childSchema.Details.Index = new(int)
 			*childSchema.Details.Index = i
-			schema.Properties[tupleChild.KeyName()] = childSchema
+			schema.Properties[abiParamName(tupleChild.KeyName(), i)] = childSchema
 		}
 	}
 	return schema

--- a/pkg/ffi2abi/ffi_test.go
+++ b/pkg/ffi2abi/ffi_test.go
@@ -1103,3 +1103,108 @@ func TestInputTypeValidForTypeComponentInvalid(t *testing.T) {
 	tc, _ := param.TypeComponentTree()
 	assert.Regexp(t, "FF22055", inputTypeValidForTypeComponent(context.Background(), inputSchema, tc))
 }
+
+func TestConvertABIToFFIAnonymousParams(t *testing.T) {
+	// Solidity allows anonymous (unnamed) parameters, e.g. an interface-only
+	// override like `function grantRole(bytes32, address) external pure {}`.
+	// These must be given unique positional names in the FFI, otherwise all
+	// anonymous params collapse into a single param named "" downstream.
+	abiJSON := []byte(`[
+		{
+			"name": "grantRole",
+			"type": "function",
+			"stateMutability": "pure",
+			"inputs": [
+				{"internalType": "bytes32", "name": "", "type": "bytes32"},
+				{"internalType": "address", "name": "", "type": "address"}
+			],
+			"outputs": [
+				{"internalType": "bool", "name": "", "type": "bool"},
+				{"internalType": "uint256", "name": "", "type": "uint256"}
+			]
+		},
+		{
+			"name": "Granted",
+			"type": "event",
+			"inputs": [
+				{"internalType": "bytes32", "name": "", "type": "bytes32", "indexed": true},
+				{"internalType": "address", "name": "", "type": "address"}
+			]
+		},
+		{
+			"name": "BadRole",
+			"type": "error",
+			"inputs": [
+				{"internalType": "bytes32", "name": "", "type": "bytes32"},
+				{"internalType": "address", "name": "", "type": "address"}
+			]
+		}
+	]`)
+	var parsedABI abi.ABI
+	err := json.Unmarshal(abiJSON, &parsedABI)
+	assert.NoError(t, err)
+
+	ffi, err := ConvertABIToFFI(context.Background(), "default", "grantable", "v0.0.1", "test", &parsedABI)
+	assert.NoError(t, err)
+
+	assert.Len(t, ffi.Methods[0].Params, 2)
+	assert.Equal(t, "0", ffi.Methods[0].Params[0].Name)
+	assert.Equal(t, "1", ffi.Methods[0].Params[1].Name)
+	assert.Len(t, ffi.Methods[0].Returns, 2)
+	assert.Equal(t, "0", ffi.Methods[0].Returns[0].Name)
+	assert.Equal(t, "1", ffi.Methods[0].Returns[1].Name)
+	assert.Equal(t, "0", ffi.Events[0].Params[0].Name)
+	assert.Equal(t, "1", ffi.Events[0].Params[1].Name)
+	assert.Equal(t, "0", ffi.Errors[0].Params[0].Name)
+	assert.Equal(t, "1", ffi.Errors[0].Params[1].Name)
+
+	// The round-trip back to ABI keeps the positional encoding and type signature intact
+	abiMethod, err := ConvertFFIMethodToABI(context.Background(), ffi.Methods[0])
+	assert.NoError(t, err)
+	assert.Equal(t, "grantRole(bytes32,address)", ABIMethodToSignature(abiMethod))
+	assert.Equal(t, "bytes32", abiMethod.Inputs[0].Type)
+	assert.Equal(t, "address", abiMethod.Inputs[1].Type)
+}
+
+func TestConvertABIToFFIAnonymousTupleMembers(t *testing.T) {
+	// Anonymous members of a tuple must also get unique positional property
+	// names in the generated JSON schema, so they cannot overwrite each other
+	abiJSON := []byte(`[
+		{
+			"name": "setPair",
+			"type": "function",
+			"inputs": [
+				{
+					"internalType": "struct Pair",
+					"name": "pair",
+					"type": "tuple",
+					"components": [
+						{"internalType": "bytes32", "name": "", "type": "bytes32"},
+						{"internalType": "address", "name": "", "type": "address"}
+					]
+				}
+			],
+			"outputs": []
+		}
+	]`)
+	var parsedABI abi.ABI
+	err := json.Unmarshal(abiJSON, &parsedABI)
+	assert.NoError(t, err)
+
+	ffi, err := ConvertABIToFFI(context.Background(), "default", "pairs", "v0.0.1", "test", &parsedABI)
+	assert.NoError(t, err)
+
+	var schema Schema
+	err = json.Unmarshal(ffi.Methods[0].Params[0].Schema.Bytes(), &schema)
+	assert.NoError(t, err)
+	assert.Len(t, schema.Properties, 2)
+	assert.Equal(t, "bytes32", schema.Properties["0"].Details.Type)
+	assert.Equal(t, 0, *schema.Properties["0"].Details.Index)
+	assert.Equal(t, "address", schema.Properties["1"].Details.Type)
+	assert.Equal(t, 1, *schema.Properties["1"].Details.Index)
+
+	// The round-trip back to ABI reconstructs the tuple components in order
+	abiMethod, err := ConvertFFIMethodToABI(context.Background(), ffi.Methods[0])
+	assert.NoError(t, err)
+	assert.Equal(t, "setPair((bytes32,address))", ABIMethodToSignature(abiMethod))
+}


### PR DESCRIPTION
## Problem

Solidity ABIs may omit parameter names entirely, e.g. an interface-only override like:

```solidity
function aFunc(bytes32, address) external pure {}
```

`ConvertABIToFFI` copied the empty name verbatim into the FFI, so two or more anonymous parameters collapsed into a single param named `""`:

- This makes invalid OpenAPI specs according to newer kin-openapi versions >= 0.144.0
- Invocation may be functionally broken - FireFly core validates and resolves inputs by `req.Input[param.Name]`, so both arguments read the same `""` key and the same value is sent for both positions.

## Fix

Anonymous function inputs/outputs, event params, error params, and tuple members now fall back to their positional index (`"0"`, `"1"`, ...). This matches the defaults the `abi` package already uses at runtime:

- input parsing: `inputparsing.go` falls back to `strconv.Itoa(i)` when looking up tuple keys
- output serialization: `NumericDefaultNameGenerator`

so FFI param names, generated docs, input lookup, and serialized output keys all align end to end.
